### PR TITLE
Remove use-package Install Guidance

### DIFF
--- a/docs/agenda.org
+++ b/docs/agenda.org
@@ -9,19 +9,9 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Install
 Add these lines to your Emacs initialization file with your binding of preference.
 #+begin_src elisp :lexical no
+  (require 'casual-agenda) ; optional if using autoloaded menu
   (keymap-set org-agenda-mode-map "C-o" #'casual-agenda-tmenu)
 #+end_src
-
-If you use ~use-package~, here is the recipe for installing it.
-#+begin_src elisp :lexical no
-  (use-package casual-agenda
-    :ensure nil
-    :bind (:map
-           org-agenda-mode-map
-           ("C-o" . casual-agenda-tmenu))
-    :after (org-agenda))
-#+end_src
-
 
 ** Configuration
 Use these bindings to configure Org Agenda to be consistent with bindings used by Casual Agenda. This is optional.
@@ -30,17 +20,6 @@ Use these bindings to configure Org Agenda to be consistent with bindings used b
   ; bindings to make jumping consistent between Org Agenda and Casual Agenda
   (keymap-set org-agenda-mode-map "M-j" #'org-agenda-clock-goto) ; optional
   (keymap-set org-agenda-mode-map "J" #'bookmark-jump) ; optional
-#+end_src
-
-If you use ~use-package~, modify your configuration as follows:
-#+begin_src elisp :lexical no
-  (use-package casual-agenda
-    :ensure nil
-    :bind (:map
-           org-agenda-mode-map
-           ("C-o" . casual-agenda-tmenu)
-           ("M-j" . org-agenda-clock-goto) ; optional
-           ("J" . bookmark-jump))) ; optional
 #+end_src
 
 

--- a/docs/bookmarks.org
+++ b/docs/bookmarks.org
@@ -8,22 +8,8 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Install
 If installed via MELPA then add these lines to your Emacs initialization file with your binding of preference. 
 #+begin_src elisp :lexical no
-  (require 'casual-bookmarks) ;; optional
+  (require 'casual-bookmarks) ; optional if using autoloaded menu
   (keymap-set bookmark-bmenu-mode-map "C-o" #'casual-bookmarks-tmenu)
-#+end_src
-
-If you use ~use-package~, here is the recipe for installing and configuring it.
-#+begin_src elisp :lexical no
-  (use-package bookmark
-    :ensure nil
-    :defer t)
-  (use-package casual-bookmarks
-    :ensure t
-    :bind (:map bookmark-bmenu-mode-map
-                ("C-o" . casual-bookmarks-tmenu)
-                ("S" . casual-bookmarks-sortby-tmenu)
-                ("J" . bookmark-jump))
-    :after (bookmark))
 #+end_src
 
 ** Configuration

--- a/docs/calc.org
+++ b/docs/calc.org
@@ -10,31 +10,10 @@ Casual Calc is available on [[https://melpa.org/#/casual-calc][MELPA]].
 
 If installed via ~list-packages~ then add this line to your Emacs initialization file.
 #+begin_src elisp :lexical no
-  (require 'casual-calc) ;; optional
+  (require 'casual-calc) ; optional if using autoloaded menu
   (keymap-set calc-mode-map "C-o" #'casual-calc-tmenu)
   (keymap-set calc-alg-map "C-o" #'casual-calc-tmenu)
 #+end_src
-
-If you use ~use-package~, here is the recipe for installing it.
-#+begin_src elisp :lexical no
-  (use-package calc
-    :defer t)
-
-  (use-package casual-calc
-    :ensure nil
-    :bind (:map
-           calc-mode-map
-           ("C-o" . casual-calc-tmenu)
-           :map
-           calc-alg-map
-           ("C-o" . casual-calc-tmenu))
-    :after (calc))
-#+end_src
-
-** A Note on Package Dependencies
-Casual Calc requires Casual Lib which in turn requires a recent installation of Transient 0.6.0+ from either [[https://elpa.gnu.org/packages/transient.html][ELPA]] or [[https://melpa.org/#/transient][MELPA]]. As an older version of Transient is built-in to the Emacs release, the package manager ~package.el~ will /not/ update this package unless the customizable variable ~package-install-upgrade-built-in~ is set to ~t~. Set this variable and proceed with installing Casual Calc. Alternately invoking ~package-install~ with a prefix (~C-u~) will temporarily coerce the update of the built-in package. (example: ~C-u M-x package-install~ ~casual-calc~)
-
-As Transient is closely tied to Magit, installing the latest version of Magit (via [[https://elpa.nongnu.org/nongnu/magit.html][non-GNU ELPA]] or [[https://melpa.org/#/magit][MELPA]]) before installing Casual Calc can also pick up the latest version of Transient.
 
 
 * Usage

--- a/docs/dired.org
+++ b/docs/dired.org
@@ -5,23 +5,30 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 
 [[file:images/casual-dired-screenshot.png]]
 
+* Requirements
+Casual Dired requires that the ~ls~ utility from GNU coreutils ≥ 8.32 be installed.
+
+The following links provide guidance for installing GNU coreutils on different platforms.
+
+** macOS
+Note that the default packaged ~ls~ on macOS is BSD-flavored which is not supported by Casual Dired. Users wishing to use Casual Dired on macOS are recommended to install GNU coreutils and configure their Emacs to point to its version of ~ls~ accordingly.
+
+- [[https://ports.macports.org/port/coreutils/][MacPorts]]
+- [[https://formulae.brew.sh/formula/coreutils#default][Homebrew]]
+
+** Windows
+For users running on Microsoft Windows, use [[https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Dired-ls.html][this guidance]] to configure Emacs to use an external install of ~ls~.
+
+- [[https://gitforwindows.org/][Git for Windows]] (includes ~ls~ in Git BASH)
+- [[https://www.cygwin.com/][Cygwin]]
+
 * Install
 If installed via MELPA then add these lines to your Emacs initialization file with your binding of preference. 
 #+begin_src elisp :lexical no
-  (require 'casual-dired) 
+  (require 'casual-dired) ; optional if using autoloaded menu
   (keymap-set dired-mode-map "C-o" #'casual-dired-tmenu)
   (keymap-set dired-mode-map "s" #'casual-dired-sort-by-tmenu) ; optional
   (keymap-set dired-mode-map "/" #'casual-dired-search-replace-tmenu) ; optional
-#+end_src
-
-If you use ~use-package~, here is the recipe for installing it.
-#+begin_src elisp :lexical no
-  (use-package casual-dired
-    :ensure t
-    :bind (:map dired-mode-map
-                ("C-o" . #'casual-dired-tmenu)
-                ("s" . #'casual-dired-sort-by-tmenu)
-                ("/" . #'casual-dired-search-replace-tmenu)))
 #+end_src
 
 In addition to binding the main menu ~casual-dired-tmenu~, the user can also bind the sort-by menu ~casual-dired-sort-by-tmenu~ and the search & replace menu ~casual-dired-search-replace-tmenu~. 
@@ -40,47 +47,13 @@ Included is a standard keymap for Dired sorting commands (~casual-dired-sort-men
   (add-hook 'dired-mode-hook 'context-menu-mode)
 #+end_src
 
-For users running on Microsoft Windows, use [[https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Dired-ls.html][this guidance]] to configure GNU ~ls~ for running with Dired.
-
-** A Note on Package Dependencies
-Casual Dired requires Casual Lib which in turn requires a recent installation of Transient 0.6.0+ from either [[https://elpa.gnu.org/packages/transient.html][ELPA]] or [[https://melpa.org/#/transient][MELPA]]. As an older version of Transient is built-in to the Emacs release, the package manager ~package.el~ will /not/ update this package unless the customizable variable ~package-install-upgrade-built-in~ is set to ~t~. Set this variable and proceed with installing Casual Dired. Alternately invoking ~package-install~ with a prefix (~C-u~) will temporarily coerce the update of the built-in package. (example: ~C-u M-x package-install~ ~casual-dired~)
-
-As Transient is closely tied to Magit, installing the latest version of Magit (via [[https://elpa.nongnu.org/nongnu/magit.html][non-GNU ELPA]] or [[https://melpa.org/#/magit][MELPA]]) before installing Casual Dired can also pick up the latest version of Transient.
 
 
-* Usage
-1. Invoke ~M-x dired~ to launch Dired.
-2. When the point is in the Dired window, invoke ~C-o~ (or a binding of your choosing) to launch the Casual Dired menu.
-
-** Enhanced Sorting
-Casual Dired offers enhanced sorting capabilities through GNU ~ls~. Use this to sort your Dired buffer to preference. Filter dot files (.*) by disabling the ~--all~ option is available here.
-
-[[file:images/casual-dired-sort-by-screenshot.png]]
-
-With the *Sort By* menu raised, one can save the switch settings for future use via the binding ~C-x C-s~ (~transient-save~). Note this is a global setting and will apply to all future calls to the *Sort By* menu.
-
-** Search & Replace
-Search and replace in multiple marked files using the ~/~ /Search & Replace/ menu item. This will raise a menu of Dired commands that will work on marked files. 
-
-[[file:images/casual-dired-search-replace.png]]
-
-While most Dired commands use Emacs-style [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Regular-Expressions.html][regular expression syntax]], there are two commands that instead take instead *grep*-style syntax:
-
-- (~g~) Find regex… (~dired-do-find-regexp~)
-- (~G~) Find regex and replace… (~dired-do-find-regexp-and-replace~)
-
-The *grep*-style syntax is dependent on the ~grep~ implementation that is installed and used by Emacs.
-
-** Bulk Dired Operations
-Casual Dired organizes a number of Dired commands that work on a set of marked files. These commands are presented in the *Utils* menu.
-
-[[file:images/casual-dired-utils-screenshot.png]]
-
-* Configuration
+** Configuration
 
 As Dired has been around for a long time, the different ways of configuring it are myriad. Described below is a configuration used by the author that is consistent with the bindings used in Casual Dired.
 
-** Initialization
+*** Initialization
 
 #+begin_src elisp :lexical no
   (require 'dired)
@@ -120,7 +93,7 @@ As Dired has been around for a long time, the different ways of configuring it a
   (keymap-set image-dired-thumbnail-mode-map "p" #'image-dired-display-previous)
 #+end_src
 
-** Variables
+*** Variables
 
 Casual Dired offers a settings menu to customize a set of commonly used Dired variables. Use this to customize your Dired behavior to taste.
 
@@ -128,13 +101,41 @@ Casual Dired offers a settings menu to customize a set of commonly used Dired va
 
 If you have GNU ~ls~ installed and configured, use the ~l~ key to set the variable ~dired-use-ls-dired~ to ~t~ ("Use GNU ‘ls’ with --dired"). Otherwise this should be disabled.
 
-** Unicode Symbol Support
+*** Unicode Symbol Support
 
 By enabling “Use Unicode Symbols” from the Settings menu, Casual Dired will use Unicode symbols as appropriate in its menus. An example is shown below.
 
 [[file:images/casual-dired-screenshot-unicode.png]]
 
 To ensure proper layout and spacing, your default typeface should be fixed-width or monospace and *must* support the Unicode symbols used.
+
+* Usage
+1. Invoke ~M-x dired~ to launch Dired.
+2. When the point is in the Dired window, invoke ~C-o~ (or a binding of your choosing) to launch the Casual Dired menu.
+
+** Enhanced Sorting
+Casual Dired offers enhanced sorting capabilities through GNU ~ls~. Use this to sort your Dired buffer to preference. Filter dot files (.*) by disabling the ~--all~ option is available here.
+
+[[file:images/casual-dired-sort-by-screenshot.png]]
+
+With the *Sort By* menu raised, one can save the switch settings for future use via the binding ~C-x C-s~ (~transient-save~). Note this is a global setting and will apply to all future calls to the *Sort By* menu.
+
+** Search & Replace
+Search and replace in multiple marked files using the ~/~ /Search & Replace/ menu item. This will raise a menu of Dired commands that will work on marked files. 
+
+[[file:images/casual-dired-search-replace.png]]
+
+While most Dired commands use Emacs-style [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Regular-Expressions.html][regular expression syntax]], there are two commands that instead take instead *grep*-style syntax:
+
+- (~g~) Find regex… (~dired-do-find-regexp~)
+- (~G~) Find regex and replace… (~dired-do-find-regexp-and-replace~)
+
+The *grep*-style syntax is dependent on the ~grep~ implementation that is installed and used by Emacs.
+
+** Bulk Dired Operations
+Casual Dired organizes a number of Dired commands that work on a set of marked files. These commands are presented in the *Utils* menu.
+
+[[file:images/casual-dired-utils-screenshot.png]]
 
 * Sponsorship
 If you enjoy using Casual Dired, consider making a modest financial contribution to help support its development and maintenance.

--- a/docs/editkit.org
+++ b/docs/editkit.org
@@ -48,15 +48,8 @@ Emacs has many commands that are easy to forget if not used frequently. Menus ar
 Typical installation of Casual EditKit is via MELPA. A reference menu (~casual-editkit-main-tmenu~) illustrating nearly all the different menus offered by Casual EditKit is provided. This menu can be used “as-is” with your binding of preference. For consistency with other Casual Packages, the binding ~C-o~ is used in the example below. Other candidate bindings include ~M-o~ and ~F10~. To facilitate default access to this menu, the configuration below sets this binding to be global which can be overridden per mode. This is /not/ mandatory and users are free to integrate Casual EditKit into their Emacs configuration however they see fit. 
 
 #+begin_src elisp :lexical no
-  (require 'casual-editkit) ;; optional
+  (require 'casual-editkit) ; optional if using autoloaded menu
   (keymap-global-set "C-o" #'casual-editkit-main-tmenu)
-#+end_src
-
-If you use ~use-package~, here is the recipe for installing and configuring it.
-#+begin_src elisp :lexical no
-  (use-package casual-editkit
-    :ensure nil
-    :bind (("C-o" . casual-editkit-main-tmenu)))
 #+end_src
 
 For motivated users desiring a bespoke solution, it is recommended that they use Casual EditKit as a library of menus to build their own workflows.

--- a/docs/info.org
+++ b/docs/info.org
@@ -8,21 +8,9 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Install
 If installed via MELPA then add these lines to your Emacs initialization file with your binding of preference. 
 #+begin_src elisp :lexical no
-  (require 'casual-info) ;; optional
+  (require 'casual-info) ; optional if using autoloaded menu
   (keymap-set Info-mode-map "C-o" #'casual-info-tmenu)
 #+end_src
-
-If you use ~use-package~, here is the recipe for installing it.
-#+begin_src elisp :lexical no
-  (use-package casual-info
-    :ensure t
-    :bind (:map Info-mode-map ("C-o" . 'casual-info-tmenu)))
-#+end_src
-
-** A Note on Package Dependencies
-Casual Info requires Casual Lib which in turn requires a recent installation of Transient 0.6.0+ from either [[https://elpa.gnu.org/packages/transient.html][ELPA]] or [[https://melpa.org/#/transient][MELPA]]. As an older version of Transient is built-in to the Emacs release, the package manager ~package.el~ will /not/ update this package unless the customizable variable ~package-install-upgrade-built-in~ is set to ~t~. Set this variable and proceed with installing Casual Info. Alternately invoking ~package-install~ with a prefix (~C-u~) will temporarily coerce the update of the built-in package. (example: ~C-u M-x package-install~ ~casual-info~)
-
-As Transient is closely tied to Magit, installing the latest version of Magit (via [[https://elpa.nongnu.org/nongnu/magit.html][non-GNU ELPA]] or [[https://melpa.org/#/magit][MELPA]]) before installing Casual Info can also pick up the latest version of Transient.
 
 ** Customization
 While not required, adding this configuration to your Emacs initialization file will synchronize keybindings between Casual Info and the Info reader. A nice visual improvement is to use ~hl-line-mode~ to highlight the line where the cursor is at. Enabling ~scroll-lock-mode~ will enable scrolling the buffer for content that is larger than its window size with the navigation keys.

--- a/docs/isearch.org
+++ b/docs/isearch.org
@@ -9,20 +9,11 @@ This package contains a [[https://github.com/magit/transient][Transient]] menu f
 * Install
 Use the following lines to install casual-isearch-tmenu.
 #+begin_src elisp :lexical yes
-  (require 'casual-isearch)
+  (require 'casual-isearch) ; optional if using autoloaded menu
   (keymap-set isearch-mode-map "C-o" #'casual-isearch-tmenu)
 #+end_src
 
-Alternately install with ~use-package~ using the following initialization:
-#+begin_src elisp :lexical no
-  (use-package casual-isearch
-    :ensure t
-    :bind (:map isearch-mode-map ("C-o" . casual-isearch-tmenu)))
-#+end_src
-
 The keybinding to ~casual-isearch-tmenu~ can be changed to user preference.
-
-
 
 * Menu Commands
 The following I-Search commands are grouped as follows in the Transient menu ~casual-isearch-tmenu~. Keys associated with each command are shown enclosed in parentheses.

--- a/docs/re-builder.org
+++ b/docs/re-builder.org
@@ -8,29 +8,10 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Install
 If installed via [[https://melpa.org/#/casual-re-builder][MELPA]] then add these lines to your Emacs initialization file with your binding of preference. 
 #+begin_src elisp :lexical no
-  (require 'casual-re-builder) ;; optional
+  (require 'casual-re-builder) ; optional
   (keymap-set reb-mode-map "C-o" #'casual-re-builder-tmenu)
   (keymap-set reb-lisp-mode-map "C-o" #'casual-re-builder-tmenu)
 #+end_src
-
-If you use ~use-package~, here is the recipe for installing and configuring it. 
-#+begin_src elisp :lexical no
-  (use-package re-builder
-    :defer t)
-
-  (use-package casual-re-builder
-    :ensure t
-    :bind (:map
-           reb-mode-map ("C-o" . casual-re-builder-tmenu)
-           :map
-           reb-lisp-mode-map ("C-o" . casual-re-builder-tmenu))
-    :after (re-builder))
-#+end_src
-
-** A Note on Package Dependencies
-Casual RE-Builder requires Casual Lib which in turn requires a recent installation of Transient 0.6.0+ from either [[https://elpa.gnu.org/packages/transient.html][ELPA]] or [[https://melpa.org/#/transient][MELPA]]. As an older version of Transient is built-in to the Emacs release, the package manager ~package.el~ will /not/ update this package unless the customizable variable ~package-install-upgrade-built-in~ is set to ~t~. Set this variable and proceed with installing Casual RE-Builder. Alternately invoking ~package-install~ with a prefix (~C-u~) will temporarily coerce the update of the built-in package. (example: ~C-u M-x package-install~ ~casual-re-builder~)
-
-As Transient is closely tied to Magit, installing the latest version of Magit (via [[https://elpa.nongnu.org/nongnu/magit.html][non-GNU ELPA]] or [[https://melpa.org/#/magit][MELPA]]) before installing Casual RE-Builder can also pick up the latest version of Transient.
 
 * Usage
 

--- a/lisp/casual-agenda.el
+++ b/lisp/casual-agenda.el
@@ -23,27 +23,16 @@
 ;; Casual Agenda is an opinionated Transient user interface for Org Agenda.
 
 ;; INSTALLATION
-;; (require 'casual-agenda) ; optional
+;; (require 'casual-agenda) ; optional if using autoloaded menu
 ;; (keymap-set org-agenda-mode-map "C-o" #'casual-agenda-tmenu)
 ;; (keymap-set org-agenda-mode-map "M-j" #'org-agenda-clock-goto) ; optional
 ;; (keymap-set org-agenda-mode-map "J" #'bookmark-jump) ; optional
 
-;; Alternately install using `use-package':
-;; (use-package casual-agenda
-;;   :ensure nil
-;;   :bind (:map
-;;          org-agenda-mode-map
-;;          ("C-o" . casual-agenda-tmenu)
-;;          ("M-j" . org-agenda-clock-goto) ; optional
-;;          ("J" . bookmark-jump)) ; optional
-;;   :after (org-agenda))
-
-;; This package requires that the built-in packages `org' and `transient' be
-;; upgraded. By default, `package.el' will not upgrade a built-in package
-;; without customization. Set the customizable variable
-;; `package-install-upgrade-built-in' to `t' to allow upgrading of built-in
-;; packages. For more details, please refer to the "Install" section on this
-;; project's repository web page.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'org-agenda)

--- a/lisp/casual-bookmarks.el
+++ b/lisp/casual-bookmarks.el
@@ -23,26 +23,14 @@
 ;; Casual Bookmarks is an opinionated Transient-based user interface for Emacs Bookmarks.
 
 ;; INSTALLATION
-;; (require 'casual-bookmarks) ;; optional
+;; (require 'casual-bookmarks) ; optional if using autoloaded menu
 ;; (keymap-set bookmark-bmenu-mode-map "C-o" #'casual-bookmarks-tmenu)
 
-;; Alternately with `use-package':
-;; (use-package bookmark
-;;   :ensure nil
-;;   :defer t)
-;; (use-package casual-bookmarks
-;;   :ensure t
-;;   :bind (:map bookmark-bmenu-mode-map
-;;               ("C-o" . casual-bookmarks-tmenu)
-;;               ("S" . casual-bookmarks-sortby-tmenu)
-;;               ("J" . bookmark-jump))
-;;   :after (bookmark))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'bookmark)

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -23,28 +23,15 @@
 ;; Casual Calc is an opinionated Transient-based user interface for Emacs Calc.
 
 ;; INSTALLATION
-;; (require 'casual-calc)
+;; (require 'casual-calc) ; optional if using autoloaded menu
 ;; (keymap-set calc-mode-map "C-o" #'casual-calc-tmenu)
 ;; (keymap-set calc-alg-map "C-o" #'casual-calc-tmenu)
 
-;; Alternately using `use-package':
-;; (use-package calc
-;;   :defer t)
-;; (use-package casual-calc
-;;   :ensure nil
-;;   :bind (:map
-;;          calc-mode-map
-;;          ("C-o" . casual-calc-tmenu)
-;;          :map
-;;          calc-alg-map
-;;          ("C-o" . casual-calc-tmenu))
-;;   :after (calc))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 

--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -23,24 +23,16 @@
 ;; Casual Dired is an opinionated Transient-based user interface for Emacs Dired.
 
 ;; INSTALLATION
-;; (require 'casual-dired)
+;; (require 'casual-dired) ; optional if using autoloaded menu
 ;; (keymap-set dired-mode-map "C-o" #'casual-dired-tmenu)
 ;; (keymap-set dired-mode-map "s" #'casual-dired-sort-by-tmenu) ; optional
 ;; (keymap-set dired-mode-map "/" #'casual-dired-search-replace-tmenu) ; optional
 
-;; Alternately, install using `use-package':
-;; (use-package casual-dired
-;;   :ensure nil
-;;   :bind (:map dired-mode-map
-;;               ("C-o" . #'casual-dired-tmenu)
-;;               ("s" . #'casual-dired-sort-by-tmenu)
-;;               ("/" . #'casual-dired-search-replace-tmenu)))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'dired)

--- a/lisp/casual-editkit.el
+++ b/lisp/casual-editkit.el
@@ -23,22 +23,17 @@
 ;; Casual EditKit is a Transient user interface toolkit for Emacs editing.
 
 ;; INSTALLATION
-;; (require 'casual-editkit) ;; optional
+;; (require 'casual-editkit) ; optional if using autoloaded menu
 ;; (keymap-global-set "C-o" #'casual-editkit-main-tmenu)
-
-;; Alternately with `use-package':
-;; (use-package casual-editkit
-;;   :ensure nil
-;;   :bind (("C-o" . casual-editkit-main-tmenu)))
 
 ;; Alternate bindings to consider are "M-o" and "F10". Choose whatever binding
 ;; best suits you.
 
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'casual-editkit-utils)

--- a/lisp/casual-ibuffer.el
+++ b/lisp/casual-ibuffer.el
@@ -23,36 +23,30 @@
 ;; Casual IBuffer is an opinionated Transient-based porcelain for Emacs IBuffer.
 
 ;; INSTALLATION
-;; (require 'casual-ibuffer) ;; optional
+;; (require 'casual-ibuffer) ; optional if using autoloaded menu
 ;; (keymap-set ibuffer-mode-map "C-o" #'casual-ibuffer-tmenu)
 ;; (keymap-set ibuffer-mode-map "F" #'casual-ibuffer-filter-tmenu)
 ;; (keymap-set ibuffer-mode-map "s" #'casual-ibuffer-sortby-tmenu)
 
-;; Alternately with `use-package':
-;; (use-package ibuffer
-;;   :hook (ibuffer-mode . ibuffer-auto-mode)
-;;   :defer t)
-;; (use-package casual-ibuffer
-;;   :ensure t
-;;   :bind (:map
-;;          ibuffer-mode-map
-;;          ("C-o" . casual-ibuffer-tmenu)
-;;          ("F" . casual-ibuffer-filter-tmenu)
-;;          ("s" . casual-ibuffer-sortby-tmenu)
-;;          ("<double-mouse-1>" . ibuffer-visit-buffer) ; optional
-;;          ("M-<double-mouse-1>" . ibuffer-visit-buffer-other-window) ; optional
-;;          ("{" . ibuffer-backwards-next-marked) ; optional
-;;          ("}" . ibuffer-forward-next-marked)   ; optional
-;;          ("[" . ibuffer-backward-filter-group) ; optional
-;;          ("]" . ibuffer-forward-filter-group)  ; optional
-;;          ("$" . ibuffer-toggle-filter-group))  ; optional
-;;   :after (ibuffer))
+;; While optional, this configuration can be used to align the bindings in
+;; `ibuffer-mode-map' with the bindings used by the Casual menus.
+;; (keymap-set ibuffer-mode-map "<double-mouse-1>" #'ibuffer-visit-buffer)
+;; (keymap-set ibuffer-mode-map "M-<double-mouse-1>" #'ibuffer-visit-buffer-other-window)
+;; (keymap-set ibuffer-mode-map "{" #'ibuffer-backwards-next-marked)
+;; (keymap-set ibuffer-mode-map "}" #'ibuffer-forward-next-marked)
+;; (keymap-set ibuffer-mode-map "[" #'ibuffer-backward-filter-group)
+;; (keymap-set ibuffer-mode-map "]" #'ibuffer-forward-filter-group)
+;; (keymap-set ibuffer-mode-map "$" #'ibuffer-toggle-filter-group)
 
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; These are some convenience hooks.
+;; (add-hook 'ibuffer-mode-hook #'hl-line-mode)
+;; (add-hook 'ibuffer-mode-hook #'ibuffer-auto-mode)
+
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'ibuffer)

--- a/lisp/casual-info.el
+++ b/lisp/casual-info.el
@@ -23,19 +23,14 @@
 ;; Casual Info is an opinionated Transient-based porcelain for Emacs Info.
 
 ;; INSTALLATION
-;; (require 'casual-info)
+;; (require 'casual-info) ; optional if using autoloaded menu
 ;; (keymap-set Info-mode-map "C-o" #'casual-info-tmenu)
 
-;; Alternately with `use-package':
-;; (use-package casual-info
-;;   :ensure nil
-;;   :bind (:map Info-mode-map ("C-o" . 'casual-info-tmenu)))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'transient)

--- a/lisp/casual-isearch.el
+++ b/lisp/casual-isearch.el
@@ -30,21 +30,16 @@
 
 ;; INSTALLATION
 ;; Enter the code below into your init file to load and install
-;; `casual-isearch-tmenu'.  Tune the keybinding to your taste.
+;; `casual-isearch-tmenu'. Tune the keybinding to your taste.
 
-;; (require 'casual-isearch)
+;; (require 'casual-isearch) ; optional if using autoloaded menu
 ;; (keymap-set isearch-mode-map "C-o" #'casual-isearch-tmenu)
 
-;; Alternately with `use-package':
-;; (use-package casual-isearch
-;;   :ensure t
-;;   :bind (:map isearch-mode-map ("C-o" . casual-isearch-tmenu)))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'casual-lib)

--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -22,11 +22,11 @@
 
 ;; Library routines for Casual user interfaces.
 
-;; INSTALLATION
-;; Casual Lib is intended to be implicitly installed as a dependency to the
-;; Casual suite of packages. If you are running Emacs 29.x, you will need to
-;; configure `package-install-upgrade-built-in' to t to support an update of the
-;; built-in package `transient'.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 'transient)

--- a/lisp/casual-re-builder.el
+++ b/lisp/casual-re-builder.el
@@ -24,26 +24,15 @@
 ;; regular expression editor.
 
 ;; INSTALLATION
-;; (require 'casual-re-builder) ;; optional
+;; (require 'casual-re-builder) ; optional if using autoloaded menu
 ;; (keymap-set reb-mode-map "C-o" #'casual-re-builder-tmenu)
 ;; (keymap-set reb-lisp-mode-map "C-o" #'casual-re-builder-tmenu)
 
-;; Alternately with `use-package'
-;; (use-package re-builder
-;;   :defer t)
-;; (use-package casual-re-builder
-;;   :ensure nil
-;;   :bind (:map
-;;          reb-mode-map ("C-o" . casual-re-builder-tmenu)
-;;          :map
-;;          reb-lisp-mode-map ("C-o" . casual-re-builder-tmenu))
-;;   :after (re-builder))
-
-;; NOTE: This package requires `casual-lib' which in turn requires an update of
-;; the built-in package `transient' ≥ 0.6.0. Please customize the variable
-;; `package-install-upgrade-built-in' to t to allow for `transient' to be
-;; updated. For further details, consult the INSTALL section of this package's
-;; README.
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
 
 ;;; Code:
 (require 're-builder)

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -81,6 +81,12 @@
 ;; This command will uninstall any Casual v1.x packages that have been
 ;; superseded by this package.
 
+;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
+;; `transient'. By default, `package.el' will not upgrade a built-in package.
+;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
+;; override this. For more details, please refer to the "Install" section on
+;; this project's repository web page.
+
 ;;; Code:
 (require 'package)
 (require 'casual-lib)


### PR DESCRIPTION
- Update documentation to remove all guidance referring to `use-package`.
- Added more guidance on GNU coreutils dependency for Casual Dired.
