### PR TITLE
Add isearch-{beginning,end}-of-buffer commands

### DIFF
--- a/lisp/casual-isearch-utils.el
+++ b/lisp/casual-isearch-utils.el
@@ -27,7 +27,9 @@
 (require 'casual-lib)
 
 (defconst casual-isearch-unicode-db
-  '((:previous . '("↑" "Previous"))
+  '((:first . '("⤒" "First"))
+    (:last . '("⤓" "Last"))
+    (:previous . '("↑" "Previous"))
     (:next . '("↓" "Next")))
 
   "Unicode symbol DB to use for RE-Builder Transient menus.")

--- a/lisp/casual-isearch.el
+++ b/lisp/casual-isearch.el
@@ -112,6 +112,12 @@
      :transient t)
     ("n" "Next" isearch-repeat-forward
      :description (lambda () (casual-isearch-unicode-get :next))
+     :transient t)
+    ("<" "First" isearch-beginning-of-buffer
+     :description (lambda () (casual-isearch-unicode-get :first))
+     :transient t)
+    (">" "Last" isearch-end-of-buffer
+     :description (lambda () (casual-isearch-unicode-get :last))
      :transient t)]]
 
   [:class transient-row

--- a/tests/test-casual-isearch-utils.el
+++ b/tests/test-casual-isearch-utils.el
@@ -30,11 +30,15 @@
 (ert-deftest test-casual-isearch-unicode-get ()
   (let ((casual-lib-use-unicode nil))
     (should (string-equal (casual-isearch-unicode-get :previous) "Previous"))
-    (should (string-equal (casual-isearch-unicode-get :next) "Next")))
+    (should (string-equal (casual-isearch-unicode-get :next) "Next"))
+    (should (string-equal (casual-isearch-unicode-get :first) "First"))
+    (should (string-equal (casual-isearch-unicode-get :last) "Last")))
 
   (let ((casual-lib-use-unicode t))
     (should (string-equal (casual-isearch-unicode-get :previous) "↑"))
-    (should (string-equal (casual-isearch-unicode-get :next) "↓"))))
+    (should (string-equal (casual-isearch-unicode-get :next) "↓"))
+    (should (string-equal (casual-isearch-unicode-get :first) "⤒"))
+    (should (string-equal (casual-isearch-unicode-get :last) "⤓"))))
 
 (provide 'test-casual-isearch-utils)
 ;;; test-casual-isearch-utils.el ends here

--- a/tests/test-casual-isearch.el
+++ b/tests/test-casual-isearch.el
@@ -70,6 +70,8 @@
                (:binding "H" :command isearch-highlight-lines-matching-regexp)
                (:binding "n" :command isearch-repeat-forward)
                (:binding "p" :command isearch-repeat-backward)
+               (:binding ">" :command isearch-end-of-buffer)
+               (:binding "<" :command isearch-beginning-of-buffer)
                (:binding "RET" :command isearch-exit))))
 
         (casualt-suffix-testcase-runner test-vectors


### PR DESCRIPTION
Having `isearch-beginning-of-buffer` and `isearch-end-of-buffer` in `casual-isearch-tmenu` seems useful to me, so here's a PR to add them. I don't mind at all if you don't want to merge this, as it's easy enough to add them in my own config with `transient-append-suffix`.

I don't know how to test the `:description` part, but hopefully it works okay (I copied the db entries from `casual-info-utils`). 

Thank you for making these packages!