### PR TITLE
Update casual-upgrade-base-to-version-2

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,7 +92,10 @@ Configuration of a particular Casual user interface is performed per mode. Go to
 - [[file:docs/re-builder.org::*Install][Re-Builder]]
 
 ** Upgrading to Casual 2.x
-If you have installed any Casual package that is version 1.x, you should immediately run the following commands upon installation of ~casual~.
+If you have been using an earlier version 1.x of Casual, thank you. Please use the following guidance:
+
+*** If you do not use ~use-package~ to configure Casual
+Before installing Casual, you should update all of your existing Casual packages. This is most easily done via the [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Package-Menu.html][package menu buffer]]. After updating your packages, install the ~casual~ package.
 
 #+BEGIN_SRC elisp
 M-x load-library casual
@@ -100,6 +103,13 @@ M-x casual-upgrade-base-to-version-2
 #+END_SRC
 
 This command will uninstall any Casual v1.x packages that have been superseded by this package.
+
+While not necessary, it is recommended to run ~M-x package-autoremove~ to purge any dangling dependent packages. Cautious readers can choose to audit any packages that are targeted to be removed.
+
+*** If you have used ~use-package~ to configure Casual
+For version 2.x going forward, I (Charles Choi) have decided to not offer any documented guidance on using ~use-package~ to configure Casual due my lack of expertise in using it. I leave it to more skilled readers to determine how to best use [[https://www.gnu.org/software/emacs/manual/html_node/use-package/][use-package]] for their configuration. Please also note that this is not a prohibition on using ~use-package~ with Casual. I am simply admitting that I don't know how to use it. 
+
+That said, if you have used ~:ensure t~ to install a superseded package, you /must/ remove that configuration. After doing so, please follow the above instructions for installing ~casual~.
 
 ** A Note on Package Dependencies
 Casual requires a recent installation of Transient 0.6.0+ from either [[https://elpa.gnu.org/packages/transient.html][ELPA]] or [[https://melpa.org/#/transient][MELPA]]. If your version of Emacs is ≤ 30 but also includes Transient as a built-in package, you will need to set the customizable variable ~package-install-upgrade-built-in~ to ~t~ to enable updating it via ~package.el~.  Set this variable and proceed with installing Casual.  Alternately invoking ~package-install~ with a prefix (~C-u~) will temporarily coerce the update of dependent built-in packages (example: ~C-u M-x package-install~ ~casual~).

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -118,7 +118,8 @@ casual-suite, casual-avy, or casual-symbol-overlay is installed."
                     'casual-ibuffer
                     'casual-info
                     'casual-isearch
-                    'casual-re-builder)))
+                    'casual-re-builder
+                    'casual-lib)))
       (mapc (lambda (pkg)
               (when (package-installed-p pkg)
                 (display-warning
@@ -128,35 +129,7 @@ casual-suite, casual-avy, or casual-symbol-overlay is installed."
                   (symbol-name pkg)))
                 (package-delete (package-get-descriptor pkg) t)
                 (package-refresh-contents)))
-            pkglist))
-
-    (let* ((pkglist (list
-                     'casual-suite
-                     'casual-avy
-                     'casual-symbol-overlay))
-           (test (seq-reduce (lambda (a b) (or a b))
-                             (mapcar #'package-installed-p pkglist)
-                             nil)))
-      ;; TODO: add this logic to upgrade existing 3rd party packages when they are ready.
-      ;; (mapc (lambda (pkg)
-      ;;         (when (package-installed-p pkg)
-      ;;           (display-warning
-      ;;            :warning
-      ;;            (format
-      ;;             "Casual 2.0 Migration: Upgrading package %s"
-      ;;             (symbol-name pkg)))
-      ;;           (package-upgrade pkg)))
-      ;;       pkglist)
-
-      ;; TODO: change logic to delete casual-lib when 3rd party packages are updated.
-      (when (and (not test) (package-installed-p 'casual-lib))
-        (display-warning
-                 :warning
-                 (format
-                  "Casual 2.0 Migration: Deleting obsolete package %s"
-                  (symbol-name 'casual-lib)))
-        (package-delete (package-get-descriptor 'casual-lib) t)
-        (package-refresh-contents)))))
+            pkglist))))
 
 (defun casual-get-package-version (pkg)
   "Get package version of symbol PKG."


### PR DESCRIPTION
- Remove logic to test for existence of casual 3rd party packages.
- Remove casual-lib package.
