### PR TITLE
Add autoload support for different casual menus

### DIFF
--- a/lisp/casual-dired-sort-by.el
+++ b/lisp/casual-dired-sort-by.el
@@ -53,6 +53,7 @@
 (require 'casual-dired-utils)
 (require 'casual-dired-variables)
 
+;;;###autoload (autoload 'casual-dired-sort-by-tmenu "casual-dired-sort-by" nil t)
 (transient-define-prefix casual-dired-sort-by-tmenu ()
   "Transient menu to sort Dired buffer by different criteria.
 

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -68,6 +68,7 @@ ASCII-range string."
           (casual-lib-quit-one)
           (casual-lib-quit-all)])
 
+;;;###autoload (autoload 'casual-dired-search-replace-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-search-replace-tmenu ()
   ["Search & Replace"
    ["Search in Files"

--- a/lisp/casual-editkit-utils.el
+++ b/lisp/casual-editkit-utils.el
@@ -114,6 +114,7 @@
        (t "Magit Status"))
     (message "Not a version controlled buffer.")))
 
+;;;###autoload (autoload 'casual-editkit-open-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-open-tmenu ()
   "Menu for ‘Open’ commands.
 
@@ -148,6 +149,7 @@ also available from here."
 
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-project-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-project-tmenu ()
   "Menu for ‘Project’ commands.
 
@@ -186,6 +188,7 @@ Commands pertaining to project operations can be accessed here."
 
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-edit-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-edit-tmenu ()
   "Menu for ‘Edit’ commands.
 
@@ -233,6 +236,7 @@ Commands pertaining to editing operations can be accessed here."
    ("U" "Undo" undo :transient t)
    (casual-lib-quit-all)])
 
+;;;###autoload (autoload 'casual-editkit-emoji-symbols-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-emoji-symbols-tmenu ()
     "Menu for ‘Emoji & Symbols’ commands.
 
@@ -284,6 +288,7 @@ inserting common miscellaneous symbols."
    ("U" "Undo" undo :transient t)
    (casual-lib-quit-all)])
 
+;;;###autoload (autoload 'casual-editkit-mark-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-mark-tmenu ()
   "Menu for ‘Mark’ commands.
 
@@ -298,6 +303,7 @@ Commands pertaining to marking operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-copy-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-copy-tmenu ()
   "Menu for ‘Copy’ commands.
 
@@ -315,6 +321,7 @@ Commands pertaining to copying can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-kill-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-kill-tmenu ()
   "Menu for ‘Kill (Cut)’ commands.
 
@@ -331,6 +338,7 @@ Commands pertaining to kill ring operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-sort-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-sort-tmenu ()
   "Menu for ‘Sort’ commands.
 
@@ -350,6 +358,7 @@ Commands pertaining to sorting operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-transpose-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-transpose-tmenu ()
   "Menu for ‘Transpose’ commands.
 
@@ -365,6 +374,7 @@ Commands pertaining to transpose operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-delete-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-delete-tmenu ()
   "Menu for ‘Delete’ commands.
 
@@ -383,6 +393,7 @@ Commands pertaining to delete can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-move-text-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-move-text-tmenu ()
   "Menu for ‘Move’ commands.
 
@@ -431,6 +442,7 @@ can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-windows-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-windows-tmenu ()
   "Menu for ‘Window’ commands.
 
@@ -504,6 +516,7 @@ Commands pertaining to window management operations can be accessed here."
 
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-windows-delete-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-windows-delete-tmenu ()
     "Menu for ‘Window Delete’ commands.
 
@@ -516,7 +529,7 @@ accessed here."
    ("f" "On Right" windmove-delete-right)]
   [(casual-lib-quit-all)])
 
-
+;;;###autoload (autoload 'casual-editkit-bookmarks-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-bookmarks-tmenu ()
     "Menu for ‘Bookmarks’ commands.
 
@@ -528,6 +541,7 @@ accessed here."
    ("J" "Jump to Bookmark…" bookmark-jump)]
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-search-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-search-tmenu ()
   "Menu for ‘Search & Replace’ commands.
 
@@ -556,7 +570,7 @@ accessed here."
 
   casual-editkit-navigation-group)
 
-
+;;;###autoload (autoload 'casual-editkit-tools-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-tools-tmenu ()
     "Menu for ‘Tools’ commands.
 
@@ -593,6 +607,7 @@ Commands pertaining to invoking different tools can be accessed here."
 
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-registers-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-registers-tmenu ()
   "Menu for ‘Registers’ commands.
 
@@ -618,6 +633,7 @@ Commands pertaining to register operations can be accessed here."
 
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-rectangle-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-rectangle-tmenu ()
   "Menu for ‘Rectangle’ commands.
 
@@ -674,6 +690,7 @@ Commands pertaining to rectangle operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-transform-text-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-transform-text-tmenu ()
   "Menu for ‘Transform’ commands.
 
@@ -687,6 +704,7 @@ Commands pertaining to transformation operations can be accessed here."
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
+;;;###autoload (autoload 'casual-editkit-macro-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-macro-tmenu ()
   "Menu for ‘Macro’ commands.
 

--- a/lisp/casual-ibuffer-filter.el
+++ b/lisp/casual-ibuffer-filter.el
@@ -63,6 +63,7 @@ The value from `ibuffer-saved-filter-groups' is used."
 (advice-add #'ibuffer-update :after #'casual-ibuffer--ibuffer-update)
 
 ;; Transients
+;;;###autoload (autoload 'casual-ibuffer-filter-tmenu "casual-ibuffer-filter" nil t)
 (transient-define-prefix casual-ibuffer-filter-tmenu ()
   "Casual IBuffer filter menu."
   :refresh-suffixes t

--- a/lisp/casual-ibuffer.el
+++ b/lisp/casual-ibuffer.el
@@ -170,6 +170,7 @@
           (casual-lib-quit-one)
           (casual-lib-quit-all)])
 
+;;;###autoload (autoload 'casual-ibuffer-sortby-tmenu "casual-ibuffer" nil t)
 (transient-define-prefix casual-ibuffer-sortby-tmenu ()
   ["IBuffer: Sort By"
    [("v" "Recency" ibuffer-do-sort-by-recency)

--- a/lisp/casual-isearch.el
+++ b/lisp/casual-isearch.el
@@ -64,6 +64,7 @@
   (isearch-toggle-symbol)
   (isearch-edit-string))
 
+;;;###autoload (autoload 'casual-isearch-tmenu "casual-isearch" nil t)
 (transient-define-prefix casual-isearch-tmenu ()
   "Transient menu for I-Search."
   [["Edit Search String"

--- a/tests/test-casual-dired.el
+++ b/tests/test-casual-dired.el
@@ -36,7 +36,8 @@
        ((symbol-function #'dired-do-async-shell-command) (lambda (x) (interactive)(print "WARNING: override")))
        ((symbol-function #'image-dired) (lambda (x) (interactive)(print "WARNING: override"))))
 
-    (let ((test-vectors (list)))
+    (let ((test-vectors (list))
+          (dired-use-ls-dired t))
       (push (casualt-suffix-test-vector "o" #'dired-find-file-other-window) test-vectors)
       (push (casualt-suffix-test-vector "v" #'dired-view-file) test-vectors)
       (push (casualt-suffix-test-vector "C" #'dired-do-copy) test-vectors)


### PR DESCRIPTION
- The following menus are now autoloaded:
  - dired
    - casual-dired-sort-by-tmenu
    - casual-dired-search-replace-tmenu
  - editkit
    - casual-editkit-open-tmenu
    - casual-editkit-project-tmenu
    - casual-editkit-edit-tmenu
    - casual-editkit-emoji-symbols-tmenu
    - casual-editkit-mark-tmenu
    - casual-editkit-copy-tmenu
    - casual-editkit-kill-tmenu
    - casual-editkit-sort-tmenu
    - casual-editkit-transpose-tmenu
    - casual-editkit-delete-tmenu
    - casual-editkit-move-text-tmenu
    - casual-editkit-windows-tmenu
    - casual-editkit-windows-delete-tmenu
    - casual-editkit-bookmarks-tmenu
    - casual-editkit-search-tmenu
    - casual-editkit-tools-tmenu
    - casual-editkit-registers-tmenu
    - casual-editkit-rectangle-tmenu
    - casual-editkit-transform-text-tmenu
    - casual-editkit-macro-tmenu
  - ibuffer
    - casual-ibuffer-filter-tmenu
    - casual-ibuffer-sortby-tmenu
  - isearch
    - casual-isearch-tmenu

- Fix unit test.
