### PR TITLE
Add shell-command to Tools menu (`casual-editkit-tools-tmenu`)

### DIFF
--- a/lisp/casual-editkit-utils.el
+++ b/lisp/casual-editkit-utils.el
@@ -578,6 +578,8 @@ Commands pertaining to invoking different tools can be accessed here."
   ["Tools"
    ["Shells & REPLs"
     ("s" "Shell" shell)
+    ("!" "Shell Command…" shell-command)
+    ("&" "Shell Command &…" async-shell-command)
     ("e" "Eshell" eshell)
     ("i" "IELM" ielm)
     ("t" "term" term)

--- a/tests/test-casual-editkit-utils.el
+++ b/tests/test-casual-editkit-utils.el
@@ -489,6 +489,8 @@
     (casualt-editkit-setup tmpfile)
     (cl-letf (;;((symbol-function #') (lambda () t))
               (casualt-mock #'shell)
+              (casualt-mock #'shell-command)
+              (casualt-mock #'async-shell-command)
               (casualt-mock #'eshell)
               (casualt-mock #'ielm)
               (casualt-mock #'term)
@@ -507,6 +509,8 @@
 
       (let ((test-vectors
              '((:binding "s" :command shell)
+               (:binding "!" :command shell-command)
+               (:binding "&" :command async-shell-command)
                (:binding "e" :command eshell)
                (:binding "i" :command ielm)
                (:binding "t" :command term)


### PR DESCRIPTION
- Added synchronous and asynchronous variants of `shell-command`
