### PR TITLE
Merge development to main 20241220_152901

### DIFF
--- a/lisp/Makefile-agenda.make
+++ b/lisp/Makefile-agenda.make
@@ -22,8 +22,8 @@ casual-agenda-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-agenda-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/Makefile-bookmarks.make
+++ b/lisp/Makefile-bookmarks.make
@@ -22,8 +22,8 @@ casual-bookmarks-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-bookmarks-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/Makefile-calendar.make
+++ b/lisp/Makefile-calendar.make
@@ -23,8 +23,8 @@ casual-calendar-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-calendar-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/Makefile-editkit.make
+++ b/lisp/Makefile-editkit.make
@@ -22,8 +22,8 @@ casual-editkit-utils.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-editkit-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transpose-frame-current	\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(EMACS_ELPA_DIR)/magit-current		\

--- a/lisp/Makefile-ibuffer.make
+++ b/lisp/Makefile-ibuffer.make
@@ -21,8 +21,8 @@ casual-ibuffer-settings.el
 ELISP_PACKAGES=casual-ibuffer-filter.el
 ELISP_TEST_INCLUDES=casual-ibuffer-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/Makefile-isearch.make
+++ b/lisp/Makefile-isearch.make
@@ -22,8 +22,8 @@ casual-isearch-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-isearch-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/Makefile-re-builder.make
+++ b/lisp/Makefile-re-builder.make
@@ -22,8 +22,8 @@ casual-re-builder-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-re-builder-test-utils.el
 PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
--L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(CASUAL_LIB_LISP_DIR)
 

--- a/lisp/casual-ibuffer-utils.el
+++ b/lisp/casual-ibuffer-utils.el
@@ -31,7 +31,7 @@
     (:next . '("↓" "Next"))
     (:jump . '("🚀" "Jump"))
     (:marked . '("❯" "Marked"))
-    (:group . '("[]" ""))
+    (:group . '("[]" "Group"))
     (:jumpgroup . '("🚀[]" "Jump to Group")))
 
   "Unicode symbol DB to use for IBuffer Transient menus.")

--- a/lisp/casual-info.el
+++ b/lisp/casual-info.el
@@ -62,7 +62,8 @@
     :pad-keys t
     ("C-s" "I-search…" isearch-forward)
     ("s" "Search…" Info-search)
-    ("S" "Case sensitive…" Info-search-case-sensitively)]
+    ("S" "Case sensitive…" Info-search-case-sensitively)
+    ("a" "Apropos…" info-apropos)]
 
    ["History"
     :pad-keys t

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.2.6
+;; Version: 2.2.7-rc.1
 ;; Package-Requires: ((emacs "29.1") (transient "0.6.0"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/tests/test-casual-ibuffer-utils.el
+++ b/tests/test-casual-ibuffer-utils.el
@@ -33,7 +33,7 @@
     (should (string-equal (casual-ibuffer-unicode-get :next) "Next"))
     (should (string-equal (casual-ibuffer-unicode-get :jump) "Jump"))
     (should (string-equal (casual-ibuffer-unicode-get :marked) "Marked"))
-    (should (string-equal (casual-ibuffer-unicode-get :group) ""))
+    (should (string-equal (casual-ibuffer-unicode-get :group) "Group"))
     (should (string-equal (casual-ibuffer-unicode-get :jumpgroup) "Jump to Group")))
 
   (let ((casual-lib-use-unicode t))

--- a/tests/test-casual-info.el
+++ b/tests/test-casual-info.el
@@ -28,59 +28,101 @@
 (require 'casual-info-test-utils)
 (require 'casual-info)
 
-(ert-deftest test-casual-info-tmenu-bindings ()
-  (casualt-info-setup)
-  (let ((test-vectors (list)))
-    (push (casualt-suffix-test-vector "d" #'Info-directory) test-vectors)
-    (push (casualt-suffix-test-vector "t" #'Info-top-node) test-vectors)
-    (push (casualt-suffix-test-vector "T" #'Info-toc) test-vectors)
-    ;;(push (casualt-suffix-test-vector "m" #'Info-menu) test-vectors)
-    ;;(push (casualt-suffix-test-vector "g" #'Info-goto-node) test-vectors)
-    ;;(push (casualt-suffix-test-vector "i" #'Info-index) test-vectors)
-    ;;(push (casualt-suffix-test-vector "I" #'Info-virtual-index) test-vectors)
+(ert-deftest test-casual-info-tmenu ()
+  (let ((tmpfile "casual-info-tmenu.txt"))
+    (casualt-info-setup)
+    (cl-letf (
+              (casualt-mock #'Info-directory)
+              (casualt-mock #'Info-top-node)
+              (casualt-mock #'Info-toc)
+              (casualt-mock #'Info-menu)
+              (casualt-mock #'Info-goto-node)
+              (casualt-mock #'Info-index)
+              (casualt-mock #'Info-virtual-index)
+              (casualt-mock #'Info-history)
+              (casualt-mock #'Info-history-back)
+              (casualt-mock #'Info-history-forward)
+              (casualt-mock #'Info-search)
+              (casualt-mock #'isearch-forward)
+              (casualt-mock #'Info-search-case-sensitively)
+              (casualt-mock #'Info-scroll-up)
+              (casualt-mock #'Info-scroll-down)
+              (casualt-mock #'Info-prev-reference)
+              (casualt-mock #'Info-next-reference)
+              (casualt-mock #'Info-backward-node)
+              (casualt-mock #'Info-forward-node)
+              (casualt-mock #'Info-prev)
+              (casualt-mock #'Info-next)
+              (casualt-mock #'Info-top-node)
+              (casualt-mock #'Info-final-node)
+              (casualt-mock #'Info-follow-nearest-node)
+              (casualt-mock #'Info-up)
+              (casualt-mock #'Info-copy-current-node-name)
+              (casualt-mock #'Info-goto-node-web)
+              (casualt-mock #'clone-buffer)
+              (casualt-mock #'bookmark-jump)
+              (casualt-mock #'bookmark-set)
+              (casualt-mock #'ibuffer)
+              (casualt-mock #'quit-window)
+              (casualt-mock #'info-apropos))
 
-    (push (casualt-suffix-test-vector "L" #'Info-history) test-vectors)
-    (push (casualt-suffix-test-vector "Û" #'Info-history-back) test-vectors)
-    (push (casualt-suffix-test-vector "Ý" #'Info-history-forward) test-vectors)
+      (let ((test-vectors
+             '(;; Overview
+               (:binding "d" :command Info-directory)
+               (:binding "t" :command Info-top-node)
+               (:binding "T" :command Info-toc)
 
-    (push (casualt-suffix-test-vector " " #'Info-scroll-up) test-vectors)
-    (push (casualt-suffix-test-vector "" #'Info-scroll-down) test-vectors)
+               ;; Goto
+               (:binding "m" :command Info-menu)
+               ;;(:binding "g" :command Info-goto-node)
+               (:binding "i" :command Info-index)
+               (:binding "I" :command Info-virtual-index)
 
-    (push (casualt-suffix-test-vector "k" #'Info-prev-reference) test-vectors)
-    (push (casualt-suffix-test-vector "j" #'Info-next-reference) test-vectors)
+               ;; Search
+               (:binding "C-s" :command isearch-forward)
+               (:binding "s" :command Info-search)
+               (:binding "S" :command Info-search-case-sensitively)
+               (:binding "a" :command info-apropos)
 
-    (push (casualt-suffix-test-vector "p" #'casual-info-browse-backward-paragraph) test-vectors)
-    (push (casualt-suffix-test-vector "n" #'casual-info-browse-forward-paragraph) test-vectors)
+               ;; History
+               (:binding "L" :command Info-history)
+               (:binding "M-[" :command Info-history-back)
+               (:binding "M-]" :command Info-history-forward)
 
-    (push (casualt-suffix-test-vector "[" #'Info-backward-node) test-vectors)
-    (push (casualt-suffix-test-vector "]" #'Info-forward-node) test-vectors)
+               ;; Scroll
+               ;;(:binding "S-SPC" :command Info-scroll-down)
+               (:binding "SPC" :command Info-scroll-up)
+               (:binding "DEL" :command Info-scroll-down)
 
-    (push (casualt-suffix-test-vector "h" #'Info-prev) test-vectors)
-    (push (casualt-suffix-test-vector "l" #'Info-next) test-vectors)
+               ;; Navigation
+               (:binding "k" :command Info-prev-reference)
+               (:binding "j" :command Info-next-reference)
+               (:binding "p" :command casual-info-browse-backward-paragraph)
+               (:binding "n" :command casual-info-browse-forward-paragraph)
+               (:binding "[" :command Info-backward-node)
+               (:binding "]" :command Info-forward-node)
+               (:binding "h" :command Info-prev)
+               (:binding "l" :command Info-next)
+               (:binding "<" :command Info-top-node)
+               (:binding ">" :command Info-final-node)
+               (:binding "RET" :command Info-follow-nearest-node)
+               (:binding "^" :command Info-up)
 
-    (push (casualt-suffix-test-vector "<" #'Info-top-node) test-vectors)
-    (push (casualt-suffix-test-vector ">" #'Info-final-node) test-vectors)
+               ;; Quick
+               (:binding "c" :command Info-copy-current-node-name)
+               (:binding "M-n" :command clone-buffer)
+               (:binding "C-M-n" :command casual-info-new-info-frame)
+               (:binding "G" :command Info-goto-node-web)
 
-    (push (casualt-suffix-test-vector "^" #'Info-up) test-vectors)
+               ;; Menu Navigation
+               (:binding "," :command casual-info-settings-tmenu)
+               (:binding "q" :command quit-window))))
 
-    (push (casualt-suffix-test-vector "J" #'bookmark-jump) test-vectors)
-    (push (casualt-suffix-test-vector "B" #'bookmark-set) test-vectors)
-    (push (casualt-suffix-test-vector "b" #'ibuffer) test-vectors)
-    (push (casualt-suffix-test-vector "c" #'Info-copy-current-node-name) test-vectors)
-    ;;(push (casualt-suffix-test-vector "G" #'Info-goto-node-web) test-vectors)
-
-    (push (casualt-suffix-test-vector "" #'casual-info-new-info-frame) test-vectors)
-    (push (casualt-suffix-test-vector "î" #'clone-buffer) test-vectors)
-    ;;(push (casualt-suffix-test-vector "" #'Info-follow-nearest-node) test-vectors)
-    ;;(push (casualt-suffix-test-vector " " #'Info-scroll-up) test-vectors)
-
-    (push (casualt-suffix-test-vector "," #'casual-info-settings-tmenu) test-vectors)
-    (push (casualt-suffix-test-vector "q" #'quit-window) test-vectors)
-
-    (casualt-suffix-testbench-runner test-vectors
-                                     #'casual-info-tmenu
-                                     '(lambda () (random 5000))))
-  (casualt-info-breakdown t))
+        (info "Emacs")
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-info-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-info-breakdown t)))
 
 (provide 'test-casual-info)
 ;;; test-casual-info.el ends here


### PR DESCRIPTION
- **Bump version to 2.2.7-rc.1**
  

- **Fix Makefile references to point to current symlinks**
  - #122 change versioned paths to symlinked to gracefully handle package updates.
  

- **Add info-apropos to Casual Info**
  - #120 Adds command `info-apropos` to `casual-info-tmenu`.
  - Update unit test for `casual-info-tmenu`.
  

- **Fix label for group label in Casual IBuffer**
  - #121 Fixes so labels that use “Group” are appropriately labeled when Unicode
  symbols are disabled.
  