### PR TITLE
feat(casual): Add customizable path for timezone database

### DIFF
--- a/lisp/casual-timezone-utils.el
+++ b/lisp/casual-timezone-utils.el
@@ -85,6 +85,11 @@ working hour in `casual-timezone-planner'."
   :type 'string
   :group 'casual)
 
+(defcustom casual-timezone-zone-info-database "/usr/share/zoneinfo/tzdata.zi"
+  "Path to the tzdata.zi file used by `casual-timezone-zone-info'."
+  :type 'file
+  :group 'casual)
+
 (defface casual-timezone-planner-working-highlight
   '((((type tty) (class color))
      :background "gray25")
@@ -108,8 +113,9 @@ working hour in `casual-timezone-planner'."
 This function reads the local zoneinfo database to obtain the
 list of timezones.
 
-This function requires that /usr/share/zoneinfo/tzdata.zi exists
-and that awk is installed."
+This function requires that the zoneinfo database in
+`casual-timezone-zone-info-database' exists and that awk is
+installed."
   (unless (not (eq system-type 'windows-nt))
     (error "Not available on Windows"))
 
@@ -119,7 +125,7 @@ and that awk is installed."
      nil
      (current-buffer)
      nil
-     "/^Z/ { print $2 }; /^L/ { print $3 }" "/usr/share/zoneinfo/tzdata.zi")
+     "/^Z/ { print $2 }; /^L/ { print $3 }" casual-timezone-zone-info-database)
     (split-string (buffer-string))))
 
 (defun casual-timezone-map-local-to-timezone (ts remote-tz)


### PR DESCRIPTION
Introduce `casual-timezone-zone-info-database` to allow users to specify the path to the tzdata.zi file.

I am a NixOS user, which does not follow the [FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html), and stores the zone-info database in a non-standard place: `/etc/zoneinfo/tzdata.zi`. This change allows me to customise the path to account for this in my configuration.

Reference: https://github.com/NixOS/nixpkgs/issues/243831