### PR TITLE
Merge development to main 20250604_110405

### DIFF
--- a/docs/casual.info
+++ b/docs/casual.info
@@ -11,7 +11,7 @@ File: casual.info,  Node: Top,  Next: Motivations,  Up: (dir)
 Casual User Guide
 *****************
 
-Version: 2.5.0
+Version: 2.5.1
 
 Casual is a project to re-imagine the primary user interface for Emacs
 using keyboard-driven menus.
@@ -1186,6 +1186,13 @@ the timezone planner.
 These variables can be customized via the Transient menu
 ‘casual-timezone-settings-tmenu’.
 
+Zoneinfo Database Configuration
+===============================
+
+The variable ‘casual-timezone-zone-info-database’ is default set to the
+path "/usr/share/zoneinfo/tzdata.zi".  Customize this variable if the
+zoneinfo database is located at a different path.
+
 
 File: casual.info,  Node: UX Conventions,  Next: Customization,  Prev: Casual Modes,  Up: Top
 
@@ -1389,6 +1396,7 @@ File: casual.info,  Node: Index,  Next: Variable Index,  Prev: Acknowledgments, 
 * Transient Conventions:                 Transient Conventions.
                                                                (line  6)
 * UX Conventions:                        UX Conventions.       (line  6)
+* Zoneinfo Database Configuration:       Timezone.             (line 88)
 
 
 File: casual.info,  Node: Variable Index,  Prev: Index,  Up: Top
@@ -1422,14 +1430,14 @@ Node: I-Search24468
 Node: Make25629
 Node: RE-Builder28013
 Node: Timezone31437
-Node: UX Conventions34567
-Node: Customization37268
-Node: Feedback & Discussion37642
-Node: Sponsorship38060
-Node: About38354
-Node: Acknowledgments38631
-Node: Index39013
-Node: Variable Index43280
+Node: UX Conventions34829
+Node: Customization37530
+Node: Feedback & Discussion37904
+Node: Sponsorship38322
+Node: About38616
+Node: Acknowledgments38893
+Node: Index39275
+Node: Variable Index43615
 
 End Tag Table
 

--- a/docs/casual.org
+++ b/docs/casual.org
@@ -6,7 +6,7 @@
 #+OPTIONS: ':t toc:t author:t email:t compact-itemx:t
 #+LANGUAGE: en
 
-#+MACRO: version 2.5.0
+#+MACRO: version 2.5.1
 
 #+TEXINFO_FILENAME: casual.info
 #+TEXINFO_HEADER: @syncodeindex pg cp
@@ -860,7 +860,13 @@ The following variables can control how working hours are displayed in the timez
 - ~casual-timezone-working-hour-glyph~ will set the glyph used to denote a working hour (default is ☼).
 - ~casual-timezone-planner-working-highlight~ will set the face used to highlight a working hour.
 
-These variables can be customized via the Transient menu ~casual-timezone-settings-tmenu~. 
+These variables can be customized via the Transient menu ~casual-timezone-settings-tmenu~.
+
+#+TEXINFO: @unnumberedsec Zoneinfo Database Configuration
+#+CINDEX: Zoneinfo Database Configuration
+
+The variable ~casual-timezone-zone-info-database~ is default set to the path "/usr/share/zoneinfo/tzdata.zi". Customize this variable if the zoneinfo database is located at a different path.
+
   
 * UX Conventions
 #+CINDEX: UX Conventions

--- a/lisp/casual-timezone-settings.el
+++ b/lisp/casual-timezone-settings.el
@@ -64,7 +64,8 @@
 
   [:class transient-row
    (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)]
+   (casual-lib-customize-hide-navigation)
+   ("D" "Zoneinfo DB" casual-timezone--customize-zone-info-database)]
 
   [:class transient-row
    (casual-lib-quit-one)
@@ -78,6 +79,14 @@
 This customizes the variable `casual-timezone-working-hour-glyph'."
   (interactive)
   (customize-variable 'casual-timezone-working-hour-glyph))
+
+
+(defun casual-timezone--customize-zone-info-database ()
+  "Set path for zoneinfo database.
+
+This customizes the variable `casual-timezone-zone-info-database'."
+  (interactive)
+  (customize-variable 'casual-timezone-zone-info-database))
 
 (defun casual-timezone--customize-planner-working-highlight ()
   "Set working hour highlight face.

--- a/lisp/casual-timezone-utils.el
+++ b/lisp/casual-timezone-utils.el
@@ -85,6 +85,11 @@ working hour in `casual-timezone-planner'."
   :type 'string
   :group 'casual)
 
+(defcustom casual-timezone-zone-info-database "/usr/share/zoneinfo/tzdata.zi"
+  "Path to the tzdata.zi file used by `casual-timezone-zone-info'."
+  :type 'file
+  :group 'casual)
+
 (defface casual-timezone-planner-working-highlight
   '((((type tty) (class color))
      :background "gray25")
@@ -108,8 +113,9 @@ working hour in `casual-timezone-planner'."
 This function reads the local zoneinfo database to obtain the
 list of timezones.
 
-This function requires that /usr/share/zoneinfo/tzdata.zi exists
-and that awk is installed."
+This function requires that the zoneinfo database in
+`casual-timezone-zone-info-database' exists and that awk is
+installed."
   (unless (not (eq system-type 'windows-nt))
     (error "Not available on Windows"))
 
@@ -119,7 +125,7 @@ and that awk is installed."
      nil
      (current-buffer)
      nil
-     "/^Z/ { print $2 }; /^L/ { print $3 }" "/usr/share/zoneinfo/tzdata.zi")
+     "/^Z/ { print $2 }; /^L/ { print $3 }" casual-timezone-zone-info-database)
     (split-string (buffer-string))))
 
 (defun casual-timezone-map-local-to-timezone (ts remote-tz)

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
 ;; Version: 2.5.1-rc.1
-;; Package-Requires: ((emacs "29.1") (transient "0.6.0"))
+;; Package-Requires: ((emacs "29.1") (transient "0.9.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -82,6 +82,10 @@
 ;;   An interface for the Emacs regular expression tool.
 ;;   URL: `https://github.com/kickingvegas/casual/blob/main/docs/re-builder.org'
 
+;; - Timezone (Elisp library: `casual-timezone')
+;;   A library of commands to work with different time zones.
+;;   URL: `https://github.com/kickingvegas/casual/blob/main/docs/timezone.org'
+
 ;; Users can choose any or all of the user interfaces made available by Casual
 ;; at their pleasure.
 
@@ -124,11 +128,11 @@
 ;; must remove that configuration. After doing so, please follow the above
 ;; instructions for installing `casual'.
 
-;; If you are using Emacs ≤ 30.0, you will need to update the built-in package
-;; `transient'. By default, `package.el' will not upgrade a built-in package.
-;; Set the customizable variable `package-install-upgrade-built-in' to `t' to
-;; override this. For more details, please refer to the "Install" section on
-;; this project's repository web page.
+;; Casual relies on the latest stable release of `transient' which may differ
+;; from the version that is preinstalled as a built-in. By b default, `package.el'
+;; will not upgrade a built-in package. Set the customizable variable
+;; `package-install-upgrade-built-in' to `t' to override this. For more details,
+;; please refer to the "Install" section on this project's repository web page.
 
 ;;; Code:
 (require 'package)

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.5.0
+;; Version: 2.5.1-rc.1
 ;; Package-Requires: ((emacs "29.1") (transient "0.6.0"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/tests/test-casual-timezone-settings.el
+++ b/tests/test-casual-timezone-settings.el
@@ -37,6 +37,7 @@
               (casualt-mock #'casual-timezone--customize-planner-working-highlight)
               (casualt-mock #'casual-timezone--customize-convert-timestamp-format)
               (casualt-mock #'casual-timezone--customize-datestamp-format)
+              (casualt-mock #'casual-timezone--customize-zone-info-database)
               (casualt-mock #'casual-timezone--describe-format-time-string))
 
       (let ((test-vectors
@@ -46,6 +47,7 @@
                (:binding "c" :command casual-timezone--customize-convert-timestamp-format)
                (:binding "p" :command casual-timezone--customize-datestamp-format)
                (:binding "f" :command casual-timezone--describe-format-time-string)
+               (:binding "D" :command casual-timezone--customize-zone-info-database)
                (:binding "a" :command casual-timezone-about)
                )))
 


### PR DESCRIPTION
- **Bump version to 2.5.1-rc.1**
  

- **feat(casual): Add customizable path for timezone database**
  Introduce `casual-timezone-zone-info-database` to allow users to
  specify the path to the tzdata.zi file.
  

- **Support casual-timezone-zone-info-database**
  - Added customization menu item to casual-timezone-settings-tmenu.
  - Updated documentation.
  

- **Update casual docstring and dependencies.**
  - Update docstring to casual.el.
  - Bump transient dependency to 0.9.0.
  