### PR TITLE
Add isearch customization switches

### DIFF
--- a/lisp/casual-isearch-settings.el
+++ b/lisp/casual-isearch-settings.el
@@ -28,22 +28,64 @@
 
 (transient-define-prefix casual-isearch-settings-tmenu ()
   "Casual I-Search settings menu."
+  :refresh-suffixes t
   ["I-Search: Settings"
-   ["Customize"
-    ("G" "I-Search Group" casual-isearch--customize-group)
-    (casual-lib-customize-unicode)
-    (casual-lib-customize-hide-navigation)]]
+    ["Allow"
+     ("s" "Scroll" casual-isearch--customize-allow-scroll)
+     ("m" "Motion" casual-isearch--customize-allow-motion
+      :description (lambda ()
+                     (casual-lib-checkbox-label isearch-allow-motion "Motion")))]
+
+    ["Lazy"
+     ("h" "Highlight" casual-isearch--customize-lazy-highlight)
+     ("c" "Count" casual-isearch--customize-lazy-count
+      :description (lambda ()
+                     (casual-lib-checkbox-label isearch-lazy-count "Count")))]
+
+    ["Misc"
+     ("G" "Group" casual-isearch--customize-group)]]
 
   [:class transient-row
-          (casual-lib-quit-one)
-          ("a" "About" casual-isearch-about :transient nil)
+   (casual-lib-customize-unicode)
+   (casual-lib-customize-hide-navigation)]
 
-          (casual-lib-quit-all)])
+  [:class transient-row
+   (casual-lib-quit-one)
+   ("a" "About" casual-isearch-about :transient nil)
+   (casual-lib-quit-all)])
 
 (defun casual-isearch--customize-group ()
   "Customize I-Search group."
   (interactive)
   (customize-group "isearch"))
+
+(defun casual-isearch--customize-allow-scroll ()
+  "Whether scrolling is allowed during incremental search.
+
+Customizes variable `isearch-allow-scroll'."
+  (interactive)
+  (customize-variable 'isearch-allow-scroll))
+
+(defun casual-isearch--customize-allow-motion ()
+  "Whether to allow movement between isearch matches by cursor motion commands.
+
+Customizes variable `isearch-allow-motion'."
+  (interactive)
+  (customize-variable 'isearch-allow-motion))
+
+(defun casual-isearch--customize-lazy-count ()
+  "Show match numbers in the search prompt.
+
+Customizes variable `isearch-lazy-count'."
+  (interactive)
+  (customize-variable 'isearch-lazy-count))
+
+(defun casual-isearch--customize-lazy-highlight ()
+  "Controls the lazy-highlighting during incremental search.
+
+Customizes variable `isearch-lazy-highlight'."
+  (interactive)
+  (customize-variable 'isearch-lazy-highlight))
 
 (defun casual-isearch-about-isearch ()
   "Casual I-Search is a Transient menu for I-Search.

--- a/tests/test-casual-isearch-settings.el
+++ b/tests/test-casual-isearch-settings.el
@@ -25,23 +25,33 @@
 ;;; Code:
 
 (require 'ert)
+(require 'casual-lib-test-utils)
 (require 'casual-isearch-test-utils)
 (require 'casual-isearch-settings)
 
-(ert-deftest test-casual-isearch-settings-tmenu-bindings ()
-  (casualt-setup)
-  (let ((test-vectors (list)))
-    (push (casualt-suffix-test-vector "G" #'casual-isearch--customize-group) test-vectors)
+(ert-deftest test-casual-isearch-settings-tmenu ()
+  (let ()
+    (casualt-setup)
+    (cl-letf ((casualt-mock #'casual-isearch--customize-group)
+              (casualt-mock #'casual-isearch--customize-allow-scroll)
+              (casualt-mock #'casual-isearch--customize-allow-motion)
+              (casualt-mock #'casual-isearch--customize-lazy-count)
+              (casualt-mock #'casual-isearch--customize-lazy-highlight))
 
-    (push (casualt-suffix-test-vector "u" #'casual-lib-customize-casual-lib-use-unicode) test-vectors)
-    (push (casualt-suffix-test-vector "n" #'casual-lib-customize-casual-lib-hide-navigation) test-vectors)
-    (push (casualt-suffix-test-vector "a" #'casual-isearch-about) test-vectors)
+      (let ((test-vectors
+             '((:binding "s" :command casual-isearch--customize-allow-scroll)
+               (:binding "m" :command casual-isearch--customize-allow-motion)
+               (:binding "h" :command casual-isearch--customize-lazy-highlight)
+               (:binding "c" :command casual-isearch--customize-lazy-count)
+               (:binding "G" :command casual-isearch--customize-group)
+               (:binding "u" :command casual-lib-customize-casual-lib-use-unicode)
+               (:binding "n" :command casual-lib-customize-casual-lib-hide-navigation)
+               (:binding "a" :command casual-isearch-about))))
 
-
-    (casualt-suffix-testbench-runner test-vectors
-                                     #'casual-isearch-settings-tmenu
-                                     '(lambda () (random 5000))))
-  (casualt-breakdown t))
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-isearch-settings-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-breakdown)))
 
 (ert-deftest test-casual-isearch-about ()
   (should (stringp (casual-isearch-about))))


### PR DESCRIPTION
- Added menu items to casual-isearch-settings-tmenu to customize:
  - isearch-allow-motion
  - isearch-allow-scroll
  - isearch-lazy-highlight
  - isearch-lazy-count

- Re-layout casual-isearch-settings-tmenu
