### PR TITLE
User defined CASUAL_BASE/LIB_DIR variables

### DIFF
--- a/lisp/Makefile--defines.make
+++ b/lisp/Makefile--defines.make
@@ -31,8 +31,8 @@ else
   EXEC_NAME=emacs
 endif
 
-CASUAL_BASE_DIR=$(HOME)/Projects/elisp
-CASUAL_LIB_DIR=$(CASUAL_BASE_DIR)/casual
+CASUAL_BASE_DIR ?= $(HOME)/Projects/elisp
+CASUAL_LIB_DIR ?= $(CASUAL_BASE_DIR)/casual
 CASUAL_LIB_LISP_DIR=$(CASUAL_LIB_DIR)/lisp
 CASUAL_LIB_TEST_INCLUDES=$(CASUAL_LIB_DIR)/tests/casual-lib-test-utils.el
 EMACS_ELPA_DIR=$(HOME)/.config/emacs/elpa


### PR DESCRIPTION
This change, while keeping the defaults, would allow users to customise their testing building environment.