### PR TITLE
Merge development to main 20250709_122042

### DIFF
--- a/lisp/casual-eshell.el
+++ b/lisp/casual-eshell.el
@@ -34,8 +34,6 @@
 
 (require 'casual-eshell-settings)
 (require 'casual-eshell-utils)
-(require 'casual-editkit)
-(require 'magit-status)
 (require 'esh-mode)
 (require 'esh-arg)
 (require 'em-hist)
@@ -56,13 +54,6 @@
     ("B" "#<buffer >…" eshell-insert-buffer-name)
     ("k" "Clear" eshell-kill-input
     :description (lambda () (casual-eshell-unicode-get :clear)))
-    ;; ("C-p" "Previous" eshell-previous-matching-input-from-input
-    ;;  :description (lambda () (casual-eshell-unicode-get :previous))
-    ;;  :transient t)
-
-    ;; ("C-n" "Next" eshell-next-matching-input-from-input
-    ;;  :description (lambda () (casual-eshell-unicode-get :next)
-    ;;  :transient t)
     ("h" "History" eshell-list-history)]
 
    ["Argument"
@@ -106,8 +97,7 @@
    ["Misc"
     ("d" "Dired" dired-jump-other-window)
     ("a" "Edit Aliases" casual-eshell-edit-aliases)
-    ("J" "Jump to Bookmark…" bookmark-jump)
-    ("g" "Magit" magit-status :if casual-editkit-version-controlled-p)]]
+    ("J" "Jump to Bookmark…" bookmark-jump)]]
 
   ["Process"
    :if (lambda () (car eshell-process-list))

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.7.0
+;; Version: 2.7.1-rc.1
 ;; Package-Requires: ((emacs "29.1") (transient "0.9.0"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -59,6 +59,11 @@
 ;;   commands.
 ;;   URL `https://github.com/kickingvegas/casual/blob/main/docs/editkit.org'
 
+;; - Eshell (Elisp library: `casual-eshell')
+;;   A user interface for Eshell, a shell-like command interpreter implemented
+;;   in Emacs Lisp.
+;;   URL `https://github.com/kickingvegas/casual/blob/main/docs/eshell.org'
+
 ;; - Image (Elisp library: `casual-image')
 ;;   An interface for viewing an image file with `image-mode'.
 ;;   Resizing an image is supported if ImageMagick 6 or 7 is installed. This


### PR DESCRIPTION
- **Bump version to 2.7.1-rc.1**
  

- **Remove dependency on magit in casual-eshell**
  - Remove call to `magit-status` in `casual-eshell-tmenu`.
  - Fix library comment for casual.el.
  