### PR TITLE
Merge development to main 20251023_120852

### DIFF
--- a/lisp/casual-timezone-utils.el
+++ b/lisp/casual-timezone-utils.el
@@ -252,7 +252,6 @@ The format of the timestamp is defined in the variable
   "." #'casual-timezone-jump-to-relative-now
   "t" #'casual-timezone-planner-current-time
   "l" #'casual-timezone-planner-current-local
-  "r" #'casual-timezone-planner-current-remote
   "f" #'casual-timezone-planner-forward-day
   "b" #'casual-timezone-planner-backward-day
   "p" #'previous-line
@@ -518,7 +517,6 @@ window width has changed."
    ["Copy Time"
     ("t" "Times" casual-timezone-planner-current-time)
     ("l" "Local" casual-timezone-planner-current-local)
-    ;; ("r" "Remote" casual-timezone-planner-current-remote)
     ("T" "Point" casual-timezone-planner-current-point)]
 
    ["Misc"

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.9.1
+;; Version: 2.9.2-rc.1
 ;; Package-Requires: ((emacs "29.1") (transient "0.9.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 2.9.2-rc.1**
  

- **Remove references to casual-timezone-planner-current-remote**
  casual-timezone-planner-current-remote is an obsolete function that has been
  removed.
  
  * lisp/casual-timezone-utils.el:
  (casual-timezone-planner-mode-map): remove 'r' binding
  (casual-timezone-planner-tmenu): remove commented code
  