### PR TITLE
Add templates for new module creation

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,0 +1,72 @@
+##
+# Copyright 2025 Charles Y. Choi
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+TIMESTAMP := $(shell /bin/date "+%Y%m%d_%H%M%S")
+INSTALL_DIR=..
+
+MODULE ?= foo
+CASUAL_MODULE=casual-$(MODULE)
+CASUAL_TEMPLATE=casual-MODULE
+
+.PHONY: source-files test-files doc-files
+
+all: source-files test-files doc-files
+
+source-files:						\
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE).el			\
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE)-utils.el		\
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE)-settings.el	\
+$(INSTALL_DIR)/lisp/Makefile-$(MODULE).make
+
+
+test-files:						\
+$(INSTALL_DIR)/tests/$(CASUAL_MODULE)-test-utils.el	\
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE).el		\
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE)-utils.el	\
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE)-settings.el
+
+doc-files: $(INSTALL_DIR)/docs/$(MODULE).org
+
+# Source Files
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE).el:
+	MODULE=$(MODULE) envsubst < lisp/$(CASUAL_TEMPLATE).el > $@
+
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE)-utils.el:
+	MODULE=$(MODULE) envsubst < lisp/$(CASUAL_TEMPLATE)-utils.el > $@
+
+$(INSTALL_DIR)/lisp/$(CASUAL_MODULE)-settings.el:
+	MODULE=$(MODULE) envsubst < lisp/$(CASUAL_TEMPLATE)-settings.el > $@
+
+$(INSTALL_DIR)/lisp/Makefile-$(MODULE).make:
+	MODULE=$(MODULE) envsubst < lisp/Makefile-MODULE.make > $@
+
+# Test Files
+$(INSTALL_DIR)/tests/$(CASUAL_MODULE)-test-utils.el:
+	MODULE=$(MODULE) envsubst < tests/$(CASUAL_TEMPLATE)-test-utils.el > $@
+
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE).el:
+	MODULE=$(MODULE) envsubst < tests/test-$(CASUAL_TEMPLATE).el > $@
+
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE)-utils.el:
+	MODULE=$(MODULE) envsubst < tests/test-$(CASUAL_TEMPLATE)-utils.el > $@
+
+$(INSTALL_DIR)/tests/test-$(CASUAL_MODULE)-settings.el:
+	MODULE=$(MODULE) envsubst < tests/test-$(CASUAL_TEMPLATE)-settings.el > $@
+
+# Doc Files
+$(INSTALL_DIR)/docs/$(MODULE).org:
+	MODULE=$(MODULE) envsubst < docs/MODULE.org > $@

--- a/templates/docs/MODULE.org
+++ b/templates/docs/MODULE.org
@@ -1,0 +1,38 @@
+* $MODULE
+#+CINDEX: $MODULE
+#+VINDEX: casual-$MODULE-tmenu
+
+Casual $MODULE is a user interface for ~$MODULE-mode~, 
+
+[[file:images/casual-$MODULE-screenshot.png]]
+
+** $MODULE Install
+:PROPERTIES:
+:CUSTOM_ID: $MODULE-install
+:END:
+
+#+CINDEX: $MODULE Install
+
+In your initialization file, bind the Transient ~casual-$MODULE-tmenu~ to your key binding of preference.
+
+#+begin_src elisp :lexical no
+  (keymap-set $MODULE-mode-map "C-o" #'casual-$MODULE-tmenu)
+#+end_src
+
+** $MODULE Usage
+#+CINDEX: $MODULE Usage
+
+[[file:images/casual-$MODULE-screenshot.png]]
+
+
+The following sections are offered in the menu:
+
+- Section1 :: description
+
+#+TEXINFO: @subheading $MODULE Settings
+
+[[file:images/casual-$MODULE-settings.png]]
+
+
+#+TEXINFO: @subheading $MODULE Unicode Symbol Support
+By enabling “{{{kbd(u)}}} Use Unicode Symbols” from the Settings menu, Casual $MODULE will use Unicode symbols as appropriate in its menus.

--- a/templates/lisp/Makefile-MODULE.make
+++ b/templates/lisp/Makefile-MODULE.make
@@ -1,0 +1,31 @@
+##
+# Copyright (C) 2025 Charles Y. Choi
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+include Makefile--defines.make
+
+PACKAGE_NAME=casual-$MODULE
+ELISP_INCLUDES=casual-$MODULE-utils.el	\
+casual-$MODULE-settings.el
+ELISP_PACKAGES=
+ELISP_TEST_INCLUDES=casual-$MODULE-test-utils.el
+PACKAGE_PATHS=					\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
+-L $(EMACS_ELPA_DIR)/transient-current		\
+-L $(EMACS_ELPA_DIR)/cond-let-current		\
+-L $(CASUAL_LIB_LISP_DIR)
+
+include Makefile--rules.make

--- a/templates/lisp/casual-MODULE-settings.el
+++ b/templates/lisp/casual-MODULE-settings.el
@@ -1,0 +1,75 @@
+;;; casual-$MODULE-settings.el --- Casual $MODULE Settings -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require '$MODULE)
+(require 'casual-lib)
+
+(transient-define-prefix casual-$MODULE-settings-tmenu ()
+  "Casual $MODULE settings menu."
+  ["Casual $MODULE: Settings"
+
+   [("G" "$MODULE Group" casual-$MODULE--customize-group)
+    (casual-lib-customize-unicode)
+    (casual-lib-customize-hide-navigation)]]
+
+  [:class transient-row
+   (casual-lib-quit-one)
+   ("a" "About" casual-$MODULE-about :transient nil)
+   (casual-lib-quit-all)])
+
+(defun casual-$MODULE--customize-group ()
+  "Customize $MODULE group."
+  (interactive)
+  (customize-group "$MODULE"))
+
+(defun casual-$MODULE-about-$MODULE ()
+  "Casual $MODULE is a Transient menu for $MODULE pages.
+
+Learn more about using Casual $MODULE at our discussion group on GitHub.
+Any questions or comments about it should be made there.
+URL `https://github.com/kickingvegas/casual/discussions'
+
+If you find a bug or have an enhancement request, please file an issue.
+Our best effort will be made to answer it.
+URL `https://github.com/kickingvegas/casual/issues'
+
+If you enjoy using Casual $MODULE, consider making a modest financial
+contribution to help support its development and maintenance.
+URL `https://www.buymeacoffee.com/kickingvegas'
+
+Casual $MODULE was conceived and crafted by Charles Choi in San Francisco,
+California.
+
+Thank you for using Casual $MODULE.
+
+Always choose love."
+  (ignore))
+
+(defun casual-$MODULE-about ()
+  "About information for Casual $MODULE."
+  (interactive)
+  (describe-function #'casual-$MODULE-about-$MODULE))
+
+(provide 'casual-$MODULE-settings)
+;;; casual-$MODULE-settings.el ends here

--- a/templates/lisp/casual-MODULE-utils.el
+++ b/templates/lisp/casual-MODULE-utils.el
@@ -1,0 +1,57 @@
+;;; casual-$MODULE-utils.el --- Casual $MODULE Utils -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require '$MODULE)
+(require 'casual-lib)
+
+(defconst casual-$MODULE-unicode-db
+  '((:previous . '("↑" "Previous"))
+    (:next . '("↓" "Next"))
+    (:goto . '("→" "Goto…"))
+    (:follow . '("🔗…" "Follow…"))
+    (:beginning-of-buffer . '("⇱" "Beginning"))
+    (:end-of-buffer . '("⇲" "End"))
+    (:paragraph . '("¶" "Paragraph"))
+    (:update . '("⟳" "Update"))
+    (:kill . '("×" "Close"))
+    (:see-also . '("👀" "See Also")))
+
+  "Unicode symbol DB to use for $MODULE Transient menus.")
+
+(defun casual-$MODULE-unicode-get (key)
+  "Lookup Unicode symbol for KEY in DB.
+
+- KEY symbol used to lookup Unicode symbol in DB.
+
+If the value of customizable variable `casual-lib-use-unicode'
+is non-nil, then the Unicode symbol is returned, otherwise a
+plain ASCII-range string."
+  (casual-lib-unicode-db-get key casual-$MODULE-unicode-db))
+
+(defun casual-$MODULE-info ()
+  "Open Info for Emacs $Module Page."
+  (interactive) (info "(emacs) $MODULE Page"))
+
+(provide 'casual-$MODULE-utils)
+;;; casual-$MODULE-utils.el ends here

--- a/templates/lisp/casual-MODULE.el
+++ b/templates/lisp/casual-MODULE.el
@@ -1,0 +1,50 @@
+;;; casual-$MODULE.el --- Transient UI for $MODULE -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This library provides a Transient-based user interface for `$MODULE-mode'.
+
+;; INSTALLATION
+
+;; In your initialization file, bind the Transient `casual-$MODULE-tmenu' to your
+;; key binding of preference.
+
+;; (require 'casual-$MODULE) ; optional if using autoloaded menu
+;; (keymap-set $MODULE-mode-map "C-o" #'casual-$MODULE-tmenu)
+
+;;; Code:
+(require 'casual-$MODULE-settings)
+(require 'casual-$MODULE-utils)
+
+;;;###autoload (autoload 'casual-$MODULE-tmenu "casual-$MODULE" nil t)
+(transient-define-prefix casual-$MODULE-tmenu ()
+  "Casual $MODULE main menu."
+
+
+  [:class transient-row
+   (casual-lib-quit-one)
+   ("," "Settings" casual-$MODULE-settings-tmenu)
+   ;; ("I" "ⓘ" casual-$MODULE-info)
+   ;; ("q" "Quit" quit-window)
+   (casual-lib-quit-all)])
+
+(provide 'casual-$MODULE)
+;;; casual-$MODULE.el ends here

--- a/templates/tests/casual-MODULE-test-utils.el
+++ b/templates/tests/casual-MODULE-test-utils.el
@@ -1,0 +1,39 @@
+;;; casual-$MODULE-test-utils.el --- Casual Test Utils       -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'ert)
+(require 'casual-lib)
+(require 'kmacro)
+
+(defun casualt-$MODULE-setup ()
+  "Casual $MODULE setup."
+  )
+
+(defun casualt-$MODULE-breakdown ()
+  "Casual $MODULE breakdown."
+  )
+
+(provide 'casual-$MODULE-test-utils)
+;;; casual-$MODULE-test-utils.el ends here

--- a/templates/tests/test-casual-MODULE-settings.el
+++ b/templates/tests/test-casual-MODULE-settings.el
@@ -1,0 +1,50 @@
+;;; test-casual-$MODULE-settings.el --- Casual Make Settings Tests  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'ert)
+(require 'casual-$MODULE-test-utils)
+(require 'casual-$MODULE-settings)
+
+(ert-deftest test-casual-$MODULE-settings-tmenu ()
+  (let ()
+    (cl-letf ((casualt-mock #'casual-$MODULE--customize-group)
+              (casualt-mock #'casual-$MODULE-about))
+
+      (let ((test-vectors
+             '((:binding "G" :com$MODULEd casual-$MODULE--customize-group)
+               (:binding "u" :com$MODULEd casual-lib-customize-casual-lib-use-unicode)
+               (:binding "n" :com$MODULEd casual-lib-customize-casual-lib-hide-navigation)
+               (:binding "a" :com$MODULEd casual-$MODULE-about))))
+
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-$MODULE-settings-tmenu
+                                        '(lambda () (random 5000)))))))
+
+(ert-deftest test-casual-$MODULE-about ()
+  (should (stringp (casual-$MODULE-about))))
+
+(provide 'test-casual-$MODULE-settings)
+;;; test-casual-$MODULE-setttings.el ends here

--- a/templates/tests/test-casual-MODULE-utils.el
+++ b/templates/tests/test-casual-MODULE-utils.el
@@ -1,0 +1,56 @@
+;;; test-casual-$MODULE-utils.el --- Casual Make Utils Tests  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'ert)
+(require 'casual-$MODULE-test-utils)
+(require 'casual-$MODULE-utils)
+
+(ert-deftest test-casual-$MODULE-unicode-get ()
+  (let ((casual-lib-use-unicode nil))
+    (should (string-equal (casual-$MODULE-unicode-get :previous) "Previous"))
+    (should (string-equal (casual-$MODULE-unicode-get :next) "Next"))
+    (should (string-equal (casual-$MODULE-unicode-get :goto) "Goto…"))
+    (should (string-equal (casual-$MODULE-unicode-get :follow) "Follow…"))
+    (should (string-equal (casual-$MODULE-unicode-get :beginning-of-buffer) "Beginning"))
+    (should (string-equal (casual-$MODULE-unicode-get :paragraph) "Paragraph"))
+    (should (string-equal (casual-$MODULE-unicode-get :update) "Update"))
+    (should (string-equal (casual-$MODULE-unicode-get :kill) "Close"))
+    (should (string-equal (casual-$MODULE-unicode-get :see-also) "See Also")))
+
+  (let ((casual-lib-use-unicode t))
+    (should (string-equal (casual-$MODULE-unicode-get :previous) "↑"))
+    (should (string-equal (casual-$MODULE-unicode-get :next) "↓"))
+    (should (string-equal (casual-$MODULE-unicode-get :goto) "→"))
+    (should (string-equal (casual-$MODULE-unicode-get :follow) "🔗…"))
+    (should (string-equal (casual-$MODULE-unicode-get :beginning-of-buffer) "⇱"))
+    (should (string-equal (casual-$MODULE-unicode-get :end-of-buffer) "⇲"))
+    (should (string-equal (casual-$MODULE-unicode-get :paragraph) "¶"))
+    (should (string-equal (casual-$MODULE-unicode-get :update) "⟳"))
+    (should (string-equal (casual-$MODULE-unicode-get :kill) "×"))
+    (should (string-equal (casual-$MODULE-unicode-get :see-also) "👀"))))
+
+
+(provide 'test-casual-$MODULE-utils)
+;;; test-casual-$MODULE-utils.el ends here

--- a/templates/tests/test-casual-MODULE.el
+++ b/templates/tests/test-casual-MODULE.el
@@ -1,0 +1,48 @@
+;;; test-casual-$MODULE.el --- Casual Make Tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Y. Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'ert)
+(require 'casual-$MODULE-test-utils)
+(require 'casual-lib-test-utils)
+(require 'casual-$MODULE)
+
+(ert-deftest test-casual-$MODULE-tmenu ()
+  (let ()
+    (casualt-$MODULE-setup)
+
+    (cl-letf ((casualt-mock #'quit-window))
+
+      (let ((test-vectors
+             '((:binding "q" :command quit-window)
+               )))
+
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-$MODULE-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-$MODULE-breakdown)))
+
+(provide 'test-casual-$MODULE)
+;;; test-casual-$MODULE.el ends here


### PR DESCRIPTION
This change adds support to add a new module using template files modified by
envsubst. This is all driven via Makefile.
