### PR TITLE
casual-timezone: Obey the TZDIR environment variable

### DIFF
--- a/lisp/casual-timezone-utils.el
+++ b/lisp/casual-timezone-utils.el
@@ -88,8 +88,13 @@ working hour in `casual-timezone-planner'."
   :type 'string
   :group 'casual)
 
-(defcustom casual-timezone-zone-info-database "/usr/share/zoneinfo/tzdata.zi"
-  "Path to the tzdata.zi file used by `casual-timezone-zone-info'."
+(defcustom casual-timezone-zone-info-database
+  (file-name-concat (or (getenv "TZDIR") "/usr/share/zoneinfo")
+                    "tzdata.zi")
+  "Path to the tzdata.zi file used by `casual-timezone-zone-info'.
+
+Defaults to $TZDIR/tzdata.zi when the TZDIR environment variable
+is set and /usr/share/zoneinfo/tzdata.zi otherwise."
   :type 'file
   :group 'casual)
 


### PR DESCRIPTION
Look for the timezone database in `TZDIR` when set. This makes `casual-timezone` work on, e.g., NixOS, without any additional configuration.