### PR TITLE
Avoid triggering warnings from casual-org-tmenu

### DIFF
--- a/lisp/casual-org.el
+++ b/lisp/casual-org.el
@@ -74,6 +74,7 @@ Emacs key bindings for movement."
   casual-org-navigation-group
 
   [:class transient-row
+   :if casual-org-mode-p
    (casual-lib-quit-one)
    ("," "Settings" casual-org-settings-tmenu)
    ("I" "ⓘ" casual-org-info


### PR DESCRIPTION
- Avoid executing org-mode dependent code when casual-org-tmenu is raised and
there is a switch to another buffer.
