### PR TITLE
Move Casual custom variables to casual group

### DIFF
--- a/lisp/casual-dired-variables.el
+++ b/lisp/casual-dired-variables.el
@@ -56,7 +56,7 @@ This variable requires GNU ‘ls’ from coreutils installed.
 
 See the man page `ls(1)' for details."
   :type '(repeat string)
-  :group 'dired)			;Please do not add your options to existing groups!
+  :group 'casual)
 
 (define-obsolete-variable-alias 'casual-dired-use-unicode-symbols
   'casual-lib-use-unicode
@@ -65,7 +65,7 @@ See the man page `ls(1)' for details."
 (defcustom casual-dired-use-unicode-symbols nil
   "If non-nil then use Unicode symbols whenever appropriate for labels."
   :type 'boolean
-  :group 'dired)
+  :group 'casual)
 
 (provide 'casual-dired-variables)
 ;;; casual-dired-variables.el ends here

--- a/lisp/casual-info-variables.el
+++ b/lisp/casual-info-variables.el
@@ -33,7 +33,7 @@
 (defcustom casual-info-use-unicode-symbols nil
   "If non-nil then use Unicode symbols whenever appropriate for labels."
   :type 'boolean
-  :group 'info)				;here again, please use your own group!
+  :group 'casual)				;here again, please use your own group!
 
 (provide 'casual-info-variables)
 ;;; casual-info-variables.el ends here


### PR DESCRIPTION
- casual-info-use-unicode-symbols
- casual-dired-listing-switches
- casual-dired-use-unicode-symbols
