### PR TITLE
Fix suffix `casual-lib-quit-one` due to Transient update

### DIFF
--- a/lisp/casual-agenda-utils.el
+++ b/lisp/casual-agenda-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-agenda-utils.el --- Casual Agenda Utils -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -58,67 +58,67 @@ plain ASCII-range string."
 ;; Casual Agenda menu navigation group.
 (transient-define-group casual-agenda-navigation-group
   [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Open" org-agenda-switch-to)
-   ("." "Now" casual-agenda-goto-now :transient t)
-   ("C-/" "Undo" org-agenda-undo :transient t)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("RET" "Open" org-agenda-switch-to)
+          ("." "Now" casual-agenda-goto-now :transient t)
+          ("C-/" "Undo" org-agenda-undo :transient t)
+          (casual-lib-quit-all)])
 
 ;; Casual Agenda navigation group within an Agenda.
 (transient-define-group casual-agenda-agenda-navigation-group
   ["Navigation"
-    ["Line"
-     ("p" "↑" org-agenda-previous-line
-      :description (lambda () (casual-agenda-unicode-get :previous))
-      :transient t)
-     ("n" "↓" org-agenda-next-line
-      :description (lambda () (casual-agenda-unicode-get :next))
-      :transient t)]
+   ["Line"
+    ("p" "↑" org-agenda-previous-line
+     :description (lambda () (casual-agenda-unicode-get :previous))
+     :transient t)
+    ("n" "↓" org-agenda-next-line
+     :description (lambda () (casual-agenda-unicode-get :next))
+     :transient t)]
 
-    ["Heading"
-     ("P" "↑ ✲" org-agenda-previous-item
-      :description (lambda () (format "%s %s"
-                                      (casual-agenda-unicode-get :previous)
-                                      (casual-agenda-unicode-get :heading)))
-      :transient t)
-     ("N" "↓ ✲" org-agenda-next-item
-      :description (lambda () (format "%s %s"
-                                      (casual-agenda-unicode-get :next)
-                                      (casual-agenda-unicode-get :heading)))
-      :transient t)]
+   ["Heading"
+    ("P" "↑ ✲" org-agenda-previous-item
+     :description (lambda () (format "%s %s"
+                                     (casual-agenda-unicode-get :previous)
+                                     (casual-agenda-unicode-get :heading)))
+     :transient t)
+    ("N" "↓ ✲" org-agenda-next-item
+     :description (lambda () (format "%s %s"
+                                     (casual-agenda-unicode-get :next)
+                                     (casual-agenda-unicode-get :heading)))
+     :transient t)]
 
-    ["Date"
+   ["Date"
+    :inapt-if-not casual-agenda-type-agendap
+    ("M-p" "↑ 📅" org-agenda-previous-date-line
+     :description (lambda () (format "%s %s"
+                                     (casual-agenda-unicode-get :previous)
+                                     (casual-agenda-unicode-get :date)))
+     :transient t)
+    ("M-n" "↓ 📅" org-agenda-next-date-line
+     :description (lambda () (format "%s %s"
+                                     (casual-agenda-unicode-get :next)
+                                     (casual-agenda-unicode-get :date)))
+     :transient t)]
+
+   ["Calendar"
+    :inapt-if-not casual-agenda-type-agendap
+    ("b" "← earlier" org-agenda-earlier :transient t)
+    ("f" "→ later" org-agenda-later :transient t)]
+
+   ["Refresh"
+    ("r" "Redo" org-agenda-redo :transient t)
+    ("g" "Redo all" org-agenda-redo-all :transient t)]
+
+   ["Jump"
+    :pad-keys t
+    ("j" "🚀 📅" org-agenda-goto-date
      :inapt-if-not casual-agenda-type-agendap
-     ("M-p" "↑ 📅" org-agenda-previous-date-line
-      :description (lambda () (format "%s %s"
-                                      (casual-agenda-unicode-get :previous)
-                                      (casual-agenda-unicode-get :date)))
-      :transient t)
-     ("M-n" "↓ 📅" org-agenda-next-date-line
-      :description (lambda () (format "%s %s"
-                                      (casual-agenda-unicode-get :next)
-                                      (casual-agenda-unicode-get :date)))
-      :transient t)]
-
-    ["Calendar"
-     :inapt-if-not casual-agenda-type-agendap
-     ("b" "← earlier" org-agenda-earlier :transient t)
-     ("f" "→ later" org-agenda-later :transient t)]
-
-    ["Refresh"
-     ("r" "Redo" org-agenda-redo :transient t)
-     ("g" "Redo all" org-agenda-redo-all :transient t)]
-
-    ["Jump"
-     :pad-keys t
-     ("j" "🚀 📅" org-agenda-goto-date
-      :inapt-if-not casual-agenda-type-agendap
-      :description (lambda () (format "%s…"
-                                      (casual-agenda-unicode-get :jumpdate))))
-     ("M-j" "🚀 ⏰" org-agenda-clock-goto
-      :inapt-if-not org-clocking-p
-      :description (lambda () (format "%s…" (casual-agenda-unicode-get :jumpclocked)))
-      :transient t)]])
+     :description (lambda () (format "%s…"
+                                     (casual-agenda-unicode-get :jumpdate))))
+    ("M-j" "🚀 ⏰" org-agenda-clock-goto
+     :inapt-if-not org-clocking-p
+     :description (lambda () (format "%s…" (casual-agenda-unicode-get :jumpclocked)))
+     :transient t)]])
 
 (defun casual-agenda-goto-now ()
   "Redo agenda view and move point to current time \"now\"."

--- a/lisp/casual-agenda.el
+++ b/lisp/casual-agenda.el
@@ -1,6 +1,6 @@
 ;;; casual-agenda.el --- Transient UI for Agenda -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -105,12 +105,12 @@
     :description (lambda () (format "%s…"
                                     (casual-agenda-unicode-get :jumpbookmark))))]
   [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Open" org-agenda-switch-to)
-   ("C-/" "Undo" org-agenda-undo)
-   ("I" "ⓘ Info" org-info-find-node)
-   ("," "Settings›" casual-agenda-settings-tmenu)
-   ("q" "Quit" org-agenda-quit)])
+          (casual-lib-quit-one)
+          ("RET" "Open" org-agenda-switch-to)
+          ("C-/" "Undo" org-agenda-undo)
+          ("I" "ⓘ Info" org-info-find-node)
+          ("," "Settings›" casual-agenda-settings-tmenu)
+          ("q" "Quit" org-agenda-quit)])
 
 (transient-define-prefix casual-agenda-almanac-tmenu ()
   "Almanac menu."
@@ -172,14 +172,14 @@
 
 (transient-define-prefix casual-agenda-mark-tmenu ()
   ["Mark"
-    :pad-keys t
-    [("m" "Mark" org-agenda-bulk-mark :transient t)
-     ("x" "Mark Regexp…" org-agenda-bulk-mark-regexp :transient t)]
-    [("u" "Unmark" org-agenda-bulk-unmark :transient t)
-     ("U" "Unmark" org-agenda-bulk-unmark-all :transient t)]
-    [("t" "Toggle" org-agenda-bulk-toggle :transient t)
-     ("T" "Toggle all" org-agenda-bulk-toggle-all :transient t)]
-    [("B" "Bulk Action…" org-agenda-bulk-action :transient t)]]
+   :pad-keys t
+   [("m" "Mark" org-agenda-bulk-mark :transient t)
+    ("x" "Mark Regexp…" org-agenda-bulk-mark-regexp :transient t)]
+   [("u" "Unmark" org-agenda-bulk-unmark :transient t)
+    ("U" "Unmark" org-agenda-bulk-unmark-all :transient t)]
+   [("t" "Toggle" org-agenda-bulk-toggle :transient t)
+    ("T" "Toggle all" org-agenda-bulk-toggle-all :transient t)]
+   [("B" "Bulk Action…" org-agenda-bulk-action :transient t)]]
 
   casual-agenda-agenda-navigation-group
   casual-agenda-navigation-group)

--- a/lisp/casual-bibtex-settings.el
+++ b/lisp/casual-bibtex-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-bibtex-settings.el --- Casual BibTeX Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -37,7 +37,7 @@
 
    ["Files"
     ("p" "Path" casual-bibtex--customize-file-path
-      :description (lambda ()
+     :description (lambda ()
                     (if bibtex-file-path
                         (format "Path (%s)" bibtex-file-path)
                       "Path")))
@@ -46,21 +46,21 @@
    ["Search"
     ("g" "Entry Globally" casual-bibtex--customize-search-entry-globally
      :description (lambda () (casual-lib-checkbox-label bibtex-search-entry-globally
-                                                   "Entry Globally")))]
+                                                        "Entry Globally")))]
 
    ["Hooks"
     ("C" "Clean" casual-bibtex--customize-clean-entry-hook)
     ("A" "Add" casual-bibtex--customize-add-entry-hook)]]
 
   ["Misc"
-    :class transient-row
-    (casual-lib-customize-unicode)
-    (casual-lib-customize-hide-navigation)]
+   :class transient-row
+   (casual-lib-customize-unicode)
+   (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-bibtex-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-bibtex-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-bibtex-about-bibtex ()
   "Casual BibTeX is a Transient menu for BibTeX.

--- a/lisp/casual-bookmarks-settings.el
+++ b/lisp/casual-bookmarks-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-bookmarks-settings.el --- Casual Bookmarks Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -30,8 +30,8 @@
   ["Bookmarks: Settings"
    ["Customize"
     ("G" "Bookmark Group" casual-bookmarks--customize-group)
-   (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)]]
+    (casual-lib-customize-unicode)
+    (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
           (casual-lib-quit-one)

--- a/lisp/casual-bookmarks.el
+++ b/lisp/casual-bookmarks.el
@@ -1,6 +1,6 @@
 ;;; casual-bookmarks.el --- Transient UI for Bookmarks -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -120,9 +120,7 @@
    ("n" "Name" casual-bookmarks-sortby-name :transient nil)
    ("m" "Last Modified" casual-bookmarks-sortby-modified :transient nil)
    ("c" "Creation Time" casual-bookmarks-sortby-creation :transient nil)]
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (defun casual-bookmarks-add-bookmark-via-buffer (buffer)
   "Set a bookmark for an interactively selected BUFFER."

--- a/lisp/casual-calc--calc.el
+++ b/lisp/casual-calc--calc.el
@@ -1,6 +1,6 @@
 ;;; casual-calc--calc.el --- Casual Wrapped Calc Functions  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -32,7 +32,7 @@
 ;;(shortdoc-add-function 'casual "Constants" '(casual-calc--pi :no-manual))
 
 (defun casual-calc--round ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -41,11 +41,11 @@ This function is a wrapper over `calc-round'.
 * References
 - info node `(calc) Integer Truncation'
 - `calc-round'"
- (interactive)
- (call-interactively #'calc-round))
+  (interactive)
+  (call-interactively #'calc-round))
 
 (defun casual-calc--floor ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -54,11 +54,11 @@ This function is a wrapper over `calc-floor'.
 * References
 - info node `(calc) Integer Truncation'
 - `calc-floor'"
- (interactive)
- (call-interactively #'calc-floor))
+  (interactive)
+  (call-interactively #'calc-floor))
 
 (defun casual-calc--ceiling ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -67,11 +67,11 @@ This function is a wrapper over `calc-ceiling'.
 * References
 - info node `(calc) Integer Truncation'
 - `calc-ceiling'"
- (interactive)
- (call-interactively #'calc-ceiling))
+  (interactive)
+  (call-interactively #'calc-ceiling))
 
 (defun casual-calc--trunc ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -80,8 +80,8 @@ This function is a wrapper over `calc-trunc'.
 * References
 - info node `(calc) Integer Truncation'
 - `calc-trunc'"
- (interactive)
- (call-interactively #'calc-trunc))
+  (interactive)
+  (call-interactively #'calc-trunc))
 
 
 (defun casual-calc--plus ()
@@ -96,8 +96,8 @@ This function is a wrapper over `calc-plus'.
 * References
 - info node `(calc) Basic Arithmetic'
 - `calc-plus'"
- (interactive)
- (call-interactively #'calc-plus))
+  (interactive)
+  (call-interactively #'calc-plus))
 
 (defun casual-calc--minus ()
   "Subtract the top two numbers on the stack and leave the result at the top (a-b).
@@ -111,11 +111,11 @@ This function is a wrapper over `calc-minus'.
 * References
 - info node `(calc) Basic Arithmetic'
 - `calc-minus'"
- (interactive)
- (call-interactively #'calc-minus))
+  (interactive)
+  (call-interactively #'calc-minus))
 
 (defun casual-calc--times ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -124,11 +124,11 @@ This function is a wrapper over `calc-times'.
 * References
 - info node `(calc) Basic Arithmetic'
 - `calc-times'"
- (interactive)
- (call-interactively #'calc-times))
+  (interactive)
+  (call-interactively #'calc-times))
 
 (defun casual-calc--divide ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -137,11 +137,11 @@ This function is a wrapper over `calc-divide'.
 * References
 - info node `(calc) Basic Arithmetic'
 - `calc-divide'"
- (interactive)
- (call-interactively #'calc-divide))
+  (interactive)
+  (call-interactively #'calc-divide))
 
 (defun casual-calc--mod ()
-    "TODO: This function does not yet have a docstring.
+  "TODO: This function does not yet have a docstring.
 \nStack Arguments:
 1: n
 
@@ -150,8 +150,8 @@ This function is a wrapper over `calc-mod'.
 * References
 - info node `(calc) Basic Arithmetic'
 - `calc-mod'"
- (interactive)
- (call-interactively #'calc-mod))
+  (interactive)
+  (call-interactively #'calc-mod))
 
 (defun casual-calc--pi ()
   "Push the value of 𝜋 at the current precision onto the stack.

--- a/lisp/casual-calc-binary.el
+++ b/lisp/casual-calc-binary.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-binary.el --- Casual Binary Menu          -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -82,8 +82,8 @@ This function is a wrapper over `calc-and'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-and'"
- (interactive)
- (call-interactively #'calc-and))
+  (interactive)
+  (call-interactively #'calc-and))
 
 (defun casual-calc--or ()
   "Computes the bitwise inclusive OR of two numbers.
@@ -96,8 +96,8 @@ This function is a wrapper over `calc-or'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-or'"
- (interactive)
- (call-interactively #'calc-or))
+  (interactive)
+  (call-interactively #'calc-or))
 
 (defun casual-calc--xor ()
   "Computes the bitwise exclusive OR of two numbers.
@@ -110,8 +110,8 @@ This function is a wrapper over `calc-xor'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-xor'"
- (interactive)
- (call-interactively #'calc-xor))
+  (interactive)
+  (call-interactively #'calc-xor))
 
 (defun casual-calc--diff ()
   "Computes the bitwise difference of two numbers.
@@ -127,8 +127,8 @@ This function is a wrapper over `calc-diff'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-diff'"
- (interactive)
- (call-interactively #'calc-diff))
+  (interactive)
+  (call-interactively #'calc-diff))
 
 (defun casual-calc--not ()
   "Computes the bitwise NOT of a number.
@@ -142,8 +142,8 @@ This function is a wrapper over `calc-not'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-not'"
- (interactive)
- (call-interactively #'calc-not))
+  (interactive)
+  (call-interactively #'calc-not))
 
 (defun casual-calc--lshift-binary ()
   "Shifts a number left by one bit.
@@ -155,11 +155,11 @@ This function is a wrapper over `calc-lshift-binary'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-lshift-binary'"
- (interactive)
- (call-interactively #'calc-lshift-binary))
+  (interactive)
+  (call-interactively #'calc-lshift-binary))
 
 (defun casual-calc--rshift-binary ()
-    "Shifts a number right by one bit.
+  "Shifts a number right by one bit.
 \nStack Arguments:
 1: n
 
@@ -168,8 +168,8 @@ This function is a wrapper over `calc-rshift-binary'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-rshift-binary'"
- (interactive)
- (call-interactively #'calc-rshift-binary))
+  (interactive)
+  (call-interactively #'calc-rshift-binary))
 
 (defun casual-calc--lshift-arith ()
   "Arithmetic shift left by one bit.
@@ -181,8 +181,8 @@ This function is a wrapper over `calc-lshift-arith'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-lshift-arith'"
- (interactive)
- (call-interactively #'calc-lshift-arith))
+  (interactive)
+  (call-interactively #'calc-lshift-arith))
 
 (defun casual-calc--rshift-arith ()
   "Arithmetic shift right by one bit.
@@ -202,8 +202,8 @@ This function is a wrapper over `calc-rshift-arith'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-rshift-arith'"
- (interactive)
- (call-interactively #'calc-rshift-arith))
+  (interactive)
+  (call-interactively #'calc-rshift-arith))
 
 (defun casual-calc--rotate-binary ()
   "Rotates a number one bit to the left.
@@ -218,11 +218,11 @@ This function is a wrapper over `calc-rotate-binary'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-rotate-binary'"
- (interactive)
- (call-interactively #'calc-rotate-binary))
+  (interactive)
+  (call-interactively #'calc-rotate-binary))
 
 (defun casual-calc--word-size ()
-    "Set the word size from a prompt.
+  "Set the word size from a prompt.
 
 This command displays a prompt with the current word size; press
 <RET> immediately to keep this word size, or type a new word size
@@ -233,11 +233,11 @@ This function is a wrapper over function `calc-word-size'.
 * References
 - info node `(calc) Binary Functions'
 - function `calc-word-size'"
- (interactive)
- (call-interactively #'calc-word-size))
+  (interactive)
+  (call-interactively #'calc-word-size))
 
 (defun casual-calc--unpack-bits ()
-    "Unpack into set of bit indexes.
+  "Unpack into set of bit indexes.
 \nStack Arguments:
 1: n
 
@@ -246,11 +246,11 @@ This function is a wrapper over `calc-unpack-bits'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-unpack-bits'"
- (interactive)
- (call-interactively #'calc-unpack-bits))
+  (interactive)
+  (call-interactively #'calc-unpack-bits))
 
 (defun casual-calc--pack-bits ()
-    "Pack set of bit indexes into a number.
+  "Pack set of bit indexes into a number.
 \nStack Arguments:
 1: n
 
@@ -259,8 +259,8 @@ This function is a wrapper over `calc-pack-bits'.
 * References
 - info node `(calc) Binary Functions'
 - `calc-pack-bits'"
- (interactive)
- (call-interactively #'calc-pack-bits))
+  (interactive)
+  (call-interactively #'calc-pack-bits))
 
 (provide 'casual-calc-binary)
 ;;; casual-calc-binary.el ends here

--- a/lisp/casual-calc-conversion.el
+++ b/lisp/casual-calc-conversion.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-conversion.el --- Casual Conversion Menu  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -48,33 +48,33 @@
                             (casual-calc-unicode-get :radians)))
      :transient t)]
 
-    ["HMS"
-     ("h" "To ℎ𝑚𝑠" calc-to-hms
-      :description (lambda ()
+   ["HMS"
+    ("h" "To ℎ𝑚𝑠" calc-to-hms
+     :description (lambda ()
                     (format "real %s %s"
                             (casual-calc-unicode-get :to)
                             (casual-calc-unicode-get :hms)))
-      :transient t)
-     ("H" "From ℎ𝑚𝑠" calc-from-hms
-      :description (lambda ()
-                     (format "%s %s real"
-                             (casual-calc-unicode-get :hms)
-                             (casual-calc-unicode-get :to)))
-      :transient t)]
+     :transient t)
+    ("H" "From ℎ𝑚𝑠" calc-from-hms
+     :description (lambda ()
+                    (format "%s %s real"
+                            (casual-calc-unicode-get :hms)
+                            (casual-calc-unicode-get :to)))
+     :transient t)]
 
-    ["Numeric"
-     ("f" "To Float" calc-float
-      :description (lambda ()
-                     (format "%s %s"
-                             (casual-calc-unicode-get :to)
-                             (casual-calc-unicode-get :float)))
-      :transient t)
-     ("F" "To Fraction" calc-fraction
-      :description (lambda ()
-                     (format "%s %s"
-                             (casual-calc-unicode-get :to)
-                             (casual-calc-unicode-get :fraction)))
-      :transient t)]]
+   ["Numeric"
+    ("f" "To Float" calc-float
+     :description (lambda ()
+                    (format "%s %s"
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :float)))
+     :transient t)
+    ("F" "To Fraction" calc-fraction
+     :description (lambda ()
+                    (format "%s %s"
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :fraction)))
+     :transient t)]]
 
   casual-calc-operators-group-row
 

--- a/lisp/casual-calc-financial.el
+++ b/lisp/casual-calc-financial.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-financial.el --- Casual Financial Menu    -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -68,9 +68,9 @@
 \nProvides menu argument support for the following function:
 - `casual-calc--fin-npv'"
   [["Net Present Value with Irregular Deposits"
-   :class transient-row
-   ("r" "Interest Rate (%)" "--rate=" :prompt "Interest Rate: ")
-   ("b" "Beginning" "--beginning")]
+    :class transient-row
+    ("r" "Interest Rate (%)" "--rate=" :prompt "Interest Rate: ")
+    ("b" "Beginning" "--beginning")]
    casual-calc-basic-operators-group]
 
   [("n" "Net Present Value (1:)" casual-calc--fin-npv :transient t)]
@@ -98,8 +98,8 @@
    ("F" "Lump Sum" casual-calc--fin-fv-lump :transient t)]
 
   ["Present Value"
-    ("p" "Periodic" casual-calc--fin-pv-periodic :transient t)
-    ("P" "Lump Sum" casual-calc--fin-pv-lump :transient t)]
+   ("p" "Periodic" casual-calc--fin-pv-periodic :transient t)
+   ("P" "Lump Sum" casual-calc--fin-pv-lump :transient t)]
 
   casual-calc-navigation-group)
 
@@ -135,7 +135,7 @@
    casual-calc-basic-operators-group]
 
   ["Projected number of payments"
-    ("n" "Number of Payments" casual-calc--fin-number-of-payments :transient t)]
+   ("n" "Number of Payments" casual-calc--fin-number-of-payments :transient t)]
 
   casual-calc-navigation-group)
 

--- a/lisp/casual-calc-graphics.el
+++ b/lisp/casual-calc-graphics.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-graphics.el --- Casual Graphics Functions  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -364,7 +364,7 @@ This string name is used in the canvas legend (key)."
    ["Utils"
     ("g" "Settings›" casual-calc-graph-settings-tmenu :transient nil)
     ("p" "Print" calc-graph-print
-     ;:description (lambda () (format "Print (%s)…" calc-gnuplot-print-device))
+                                        ;:description (lambda () (format "Print (%s)…" calc-gnuplot-print-device))
      :transient nil)
     ("C" "Raw Command…" calc-graph-command :transient nil)]
    casual-calc-operators-group]
@@ -447,13 +447,13 @@ This string name is used in the canvas legend (key)."
 (transient-define-prefix casual-calc-graph-settings-tmenu ()
   "Graphics settings menu."
   ["Graphics Settings"
-    ("d" "Set Device…" calc-graph-device
-     ;:description (lambda () (format "Device (%s)…" calc-gnuplot-default-device)) this variable only initializes.
-     :transient nil)
-    ("o" "Set Output File…" calc-graph-output
-     ;:description (lambda () (format "Output (%s)…" calc-gnuplot-default-output))
-     :transient nil)
-    ("Q" "Quit Gnuplot Session" calc-graph-quit :transient nil)]
+   ("d" "Set Device…" calc-graph-device
+                                        ;:description (lambda () (format "Device (%s)…" calc-gnuplot-default-device)) this variable only initializes.
+    :transient nil)
+   ("o" "Set Output File…" calc-graph-output
+                                        ;:description (lambda () (format "Output (%s)…" calc-gnuplot-default-output))
+    :transient nil)
+   ("Q" "Quit Gnuplot Session" calc-graph-quit :transient nil)]
 
   casual-calc-navigation-group)
 

--- a/lisp/casual-calc-settings.el
+++ b/lisp/casual-calc-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-settings.el --- Casual Settings Menu      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -44,7 +44,7 @@
     ("z" "Leading Zeroes" calc-leading-zeros
      :description (lambda ()
                     (casual-lib-checkbox-label calc-leading-zeros
-                                            "Leading Zeroes"))
+                                               "Leading Zeroes"))
      :transient t)
 
     ("F" calc-frac-mode :description casual-calc-prefer-frac-label :transient t)
@@ -63,7 +63,7 @@
     ("I" "Infinite Mode" casual-calc--infinite-mode
      :description (lambda ()
                     (casual-lib-checkbox-label calc-infinite-mode
-                                            "Infinite Mode"))
+                                               "Infinite Mode"))
      :transient t)]
 
    ["Angular Measure"
@@ -87,7 +87,7 @@
      ;; TODO calc-group-digits can actually be an int 😦
      :description (lambda ()
                     (casual-lib-checkbox-label calc-group-digits
-                                            "Show Thousands Separators"))
+                                               "Show Thousands Separators"))
      :transient t)
     ("," "Thousands Separator…" calc-group-char
      :description (lambda ()

--- a/lisp/casual-calc-symbolic.el
+++ b/lisp/casual-calc-symbolic.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-symbolic.el --- Casual Symbolic Menu      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -83,7 +83,7 @@
     ("A" calc-algebraic-mode
      :description (lambda ()
                     (casual-lib-checkbox-label calc-algebraic-mode
-                                            "Algebraic Mode"))
+                                               "Algebraic Mode"))
      :transient t)
     ("M" calc-symbolic-mode :description casual-calc-symbolic-mode-label :transient t)
     ("a" casual-calc-angle-measure-tmenu
@@ -140,11 +140,11 @@
   "Symbolic Manipulation Menu.
 Commands to manipulate a symbolic expression."
   [["Symbolic Manipulation"
-   ("E" "Simplify" casual-calc--alg-evaluate :transient t)
-   ("=" "Evaluate Variables" casual-calc--evaluate :transient t)
-   ("e" "Expand Formula" casual-calc--expand-formula :transient t)
-   ("m" "Map Equation" casual-calc--map-equation :transient t)
-   ("s" "Substitute" casual-calc--substitute :transient t)]
+    ("E" "Simplify" casual-calc--alg-evaluate :transient t)
+    ("=" "Evaluate Variables" casual-calc--evaluate :transient t)
+    ("e" "Expand Formula" casual-calc--expand-formula :transient t)
+    ("m" "Map Equation" casual-calc--map-equation :transient t)
+    ("s" "Substitute" casual-calc--substitute :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)
@@ -154,25 +154,25 @@ Commands to manipulate a symbolic expression."
   "Polynomial Menu.
 Commands to manipulate a polynomial expression."
   [["Polynomials"
-   ("f" "Factor" casual-calc--factor :transient t)
-   ("e" "Expand" casual-calc--expand :transient t)
-   ("c" "Collect…" casual-calc--collect :transient t)
-   ("a" "Apart" casual-calc--apart :transient t)
-   ("n" "Normalize Ratio" casual-calc--normalize-rat :transient t)
-   ("\\" "Polynomial Divide" casual-calc--poly-div :transient t)
-   ("%" "Polynomial Remainder" casual-calc--poly-rem :transient t)
-   ("/" "Polynomial Divide & Remainder" casual-calc--poly-div-rem :transient t)
-   ("g" "Polynomial GCD" casual-calc--poly-gcd :transient t)]]
+    ("f" "Factor" casual-calc--factor :transient t)
+    ("e" "Expand" casual-calc--expand :transient t)
+    ("c" "Collect…" casual-calc--collect :transient t)
+    ("a" "Apart" casual-calc--apart :transient t)
+    ("n" "Normalize Ratio" casual-calc--normalize-rat :transient t)
+    ("\\" "Polynomial Divide" casual-calc--poly-div :transient t)
+    ("%" "Polynomial Remainder" casual-calc--poly-rem :transient t)
+    ("/" "Polynomial Divide & Remainder" casual-calc--poly-div-rem :transient t)
+    ("g" "Polynomial GCD" casual-calc--poly-gcd :transient t)]]
   casual-calc-navigation-group)
 
 (transient-define-prefix casual-calc--calculus-tmenu ()
   "Calculus Menu.
 Commands to perform Calculus."
   [["Calculus"
-   ("n" "Numeric Integral…" casual-calc--num-integral :transient t)
-   ("t" "Taylor…" casual-calc--taylor :transient t)
-   ("d" "Derivative…" casual-calc--derivative :transient t)
-   ("i" "Integral…" casual-calc--integral :transient t)]
+    ("n" "Numeric Integral…" casual-calc--num-integral :transient t)
+    ("t" "Taylor…" casual-calc--taylor :transient t)
+    ("d" "Derivative…" casual-calc--derivative :transient t)
+    ("i" "Integral…" casual-calc--integral :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)
@@ -181,8 +181,8 @@ Commands to perform Calculus."
   "Symbolic Solve Menu.
 Commands to solve an algebraic expression symbolically."
   [["Symbolic Solutions"
-   ("s" "Solve for…" casual-calc--solve-for :transient t)
-   ("p" "Polynomial roots for…" casual-calc--poly-roots :transient t)]
+    ("s" "Solve for…" casual-calc--solve-for :transient t)
+    ("p" "Polynomial roots for…" casual-calc--poly-roots :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)
@@ -191,11 +191,11 @@ Commands to solve an algebraic expression symbolically."
   "Numerica Solve Menu.
 Commands to solve an algebraic expression numerically."
   [["Numerical Solutions"
-   ("r" "Find Root" casual-calc--find-root :transient t)
-   ("m" "Find Minimum…" casual-calc--find-minimum :transient t)
-   ("x" "Find Maximum…" casual-calc--find-maximum :transient t)
-   ("h" "Head" casual-calc--head :transient t)
-   ("w" "Why" casual-calc--why :transient t)]
+    ("r" "Find Root" casual-calc--find-root :transient t)
+    ("m" "Find Minimum…" casual-calc--find-minimum :transient t)
+    ("x" "Find Maximum…" casual-calc--find-maximum :transient t)
+    ("h" "Head" casual-calc--head :transient t)
+    ("w" "Why" casual-calc--why :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)
@@ -204,9 +204,9 @@ Commands to solve an algebraic expression numerically."
   "Curve Fit Menu.
 Curve fit commands."
   [["Curve Fit"
-   ("c" "Curve Fit" casual-calc--curve-fit :transient t)
-   ("p" "Polynomial Interpolation" casual-calc--poly-interp :transient t)
-   ("o" "Open Curve Fit Data…" casual-calc-read-curvefit-data :transient t)]
+    ("c" "Curve Fit" casual-calc--curve-fit :transient t)
+    ("p" "Polynomial Interpolation" casual-calc--poly-interp :transient t)
+    ("o" "Open Curve Fit Data…" casual-calc-read-curvefit-data :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)
@@ -215,10 +215,10 @@ Curve fit commands."
   "Summations Menu.
 Summation commands."
   [["Summations"
-   ("s" "𝚺" casual-calc--summation :transient t)
-   ("a" "𝚺 alternating" casual-calc--alt-summation :transient t)
-   ("p" "𝚷" casual-calc--product :transient t)
-   ("t" "Tabulate" casual-calc--tabulate :transient t)]
+    ("s" "𝚺" casual-calc--summation :transient t)
+    ("a" "𝚺 alternating" casual-calc--alt-summation :transient t)
+    ("p" "𝚷" casual-calc--product :transient t)
+    ("t" "Tabulate" casual-calc--tabulate :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)

--- a/lisp/casual-calc-time.el
+++ b/lisp/casual-calc-time.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-time.el --- Casual Time Menu              -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -35,9 +35,9 @@
   (interactive)
   (unless (derived-mode-p 'calc-mode) (error "Not in calc mode"))
   (let* ((ts (org-read-date t nil nil nil nil
-                           (format-time-string
-                            "%H:%M"
-                            (current-time))))
+                            (format-time-string
+                             "%H:%M"
+                             (current-time))))
          (calc-ts (math-parse-date ts)))
     (calc-push calc-ts)))
 

--- a/lisp/casual-calc-trigonometric.el
+++ b/lisp/casual-calc-trigonometric.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-trigonometric.el --- Casual Trigonometric Menus  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -70,15 +70,15 @@
      :transient t)]]
 
   [:class transient-row
-   ("p" "𝜋" casual-calc--pi
-     :description (lambda () (casual-calc-unicode-get :pi))
-     :transient t)
-   ("a" casual-calc-angle-measure-tmenu
-     :description (lambda ()
-                    (format "Angle Measure (now %s)›"
-                            (casual-calc-angle-mode-label)))
-     :transient t)
-   ("h" "Hyperbolic›" casual-calc-hyperbolic-trig-tmenu)]
+          ("p" "𝜋" casual-calc--pi
+           :description (lambda () (casual-calc-unicode-get :pi))
+           :transient t)
+          ("a" casual-calc-angle-measure-tmenu
+           :description (lambda ()
+                          (format "Angle Measure (now %s)›"
+                                  (casual-calc-angle-mode-label)))
+           :transient t)
+          ("h" "Hyperbolic›" casual-calc-hyperbolic-trig-tmenu)]
 
   casual-calc-operators-group-row
   casual-calc-navigation-group)

--- a/lisp/casual-calc-units.el
+++ b/lisp/casual-calc-units.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-units.el --- Casual Units                 -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -31,14 +31,14 @@
 (transient-define-prefix casual-calc-units-tmenu ()
   "Casual unit conversions menu."
   [["Unit Conversions"
-   ("c" "Convert" calc-convert-units :transient t)
-   ("t" "Convert Temperature" calc-convert-temperature :transient t)
-   ("b" "Convert to Base Unit" calc-base-units :transient t)
-   ;; TODO: display current autorange state
-   ;;("a" "Autorange" calc-autorange-units :transient t)
-   ("r" "Remove Units" calc-remove-units :transient t)
-   ("x" "Extract Units" calc-extract-units :transient t)
-   ("v" "View Units" calc-view-units-table :transient t)]
+    ("c" "Convert" calc-convert-units :transient t)
+    ("t" "Convert Temperature" calc-convert-temperature :transient t)
+    ("b" "Convert to Base Unit" calc-base-units :transient t)
+    ;; TODO: display current autorange state
+    ;;("a" "Autorange" calc-autorange-units :transient t)
+    ("r" "Remove Units" calc-remove-units :transient t)
+    ("x" "Extract Units" calc-extract-units :transient t)
+    ("v" "View Units" calc-view-units-table :transient t)]
    casual-calc-operators-group]
 
   casual-calc-navigation-group)

--- a/lisp/casual-calc-utils.el
+++ b/lisp/casual-calc-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-utils.el --- Casual Calc Utils       -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -124,28 +124,28 @@ Invokes command `calc-roll-down'."
 
 (transient-define-group casual-calc-operators-group
   ["Operators"
-    ("+" "add" casual-calc--plus :transient t)
-    ("-" "sub" casual-calc--minus :transient t)
-    ("*" "mul" casual-calc--times :transient t)
-    ("/" "div" casual-calc--divide :transient t)
-    ("%" "mod" casual-calc--mod :transient t)])
+   ("+" "add" casual-calc--plus :transient t)
+   ("-" "sub" casual-calc--minus :transient t)
+   ("*" "mul" casual-calc--times :transient t)
+   ("/" "div" casual-calc--divide :transient t)
+   ("%" "mod" casual-calc--mod :transient t)])
 
 (transient-define-group casual-calc-operators-group-row
   ["Operators"
    :class transient-row
-    ("+" "add" casual-calc--plus :transient t)
-    ("-" "sub" casual-calc--minus :transient t)
-    ("*" "mul" casual-calc--times :transient t)
-    ("/" "div" casual-calc--divide :transient t)
-    ("%" "mod" casual-calc--mod :transient t)])
+   ("+" "add" casual-calc--plus :transient t)
+   ("-" "sub" casual-calc--minus :transient t)
+   ("*" "mul" casual-calc--times :transient t)
+   ("/" "div" casual-calc--divide :transient t)
+   ("%" "mod" casual-calc--mod :transient t)])
 
 (transient-define-group casual-calc-basic-operators-group
   ["Operators"
-    ("+" "add" casual-calc--plus :transient t)
-    ("-" "sub" casual-calc--minus :transient t)
-    ("*" "mul" casual-calc--times :transient t)
-    ("/" "div" casual-calc--divide :transient t)
-    ("M" "mod" casual-calc--mod :transient t)])
+   ("+" "add" casual-calc--plus :transient t)
+   ("-" "sub" casual-calc--minus :transient t)
+   ("*" "mul" casual-calc--times :transient t)
+   ("/" "div" casual-calc--divide :transient t)
+   ("M" "mod" casual-calc--mod :transient t)])
 
 (transient-define-group casual-calc-navigation-group
   [:class transient-row

--- a/lisp/casual-calc-variables.el
+++ b/lisp/casual-calc-variables.el
@@ -47,11 +47,11 @@ menu."
     ("i" "Insert variables into buffer…" casual-calc--insert-variables :transient nil)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   (casual-calc-algebraic-entry)
-   (casual-calc-pop)
-   (casual-calc-undo-suffix)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          (casual-calc-algebraic-entry)
+          (casual-calc-pop)
+          (casual-calc-undo-suffix)
+          (casual-lib-quit-all)])
 
 (provide 'casual-calc-variables)
 ;;; casual-calc-variables.el ends here

--- a/lisp/casual-calc-vector.el
+++ b/lisp/casual-calc-vector.el
@@ -1,6 +1,6 @@
 ;;; casual-calc-vector.el --- Casual Vector Menu          -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -33,11 +33,11 @@
   "Casual vector and matrix functions top-level menu."
   ["Vector & Matrix Functions (index is 1-offset)\n"
    ["Categories"
-   ("b" "Building›" casual-calc-vector-building-tmenu)
-   ("a" "Arithmetic›" casual-calc-vector-arithmetic-tmenu)
-   ("s" "Statistics›" casual-calc-statistics-tmenu)
-   ("S" "Set Operations›" casual-calc-set-operations-tmenu)
-   ("m" "Map, Reduce, Apply›" casual-calc-map-and-reduce-tmenu)]
+    ("b" "Building›" casual-calc-vector-building-tmenu)
+    ("a" "Arithmetic›" casual-calc-vector-arithmetic-tmenu)
+    ("s" "Statistics›" casual-calc-statistics-tmenu)
+    ("S" "Set Operations›" casual-calc-set-operations-tmenu)
+    ("m" "Map, Reduce, Apply›" casual-calc-map-and-reduce-tmenu)]
 
    ["Manipulate"
     :pad-keys t
@@ -148,10 +148,10 @@
 (transient-define-prefix casual-calc-map-and-reduce-tmenu ()
   "Casual functional operations (map, reduce, apply) menu."
   [["Functional Operators"
-   ("m" "map" calc-map :transient t)
-   ("r" "reduce" calc-reduce :transient t)
-   ("a" "apply" calc-apply :transient t)
-   ("A" "accumulate" calc-accumulate :transient t)]
+    ("m" "map" calc-map :transient t)
+    ("r" "reduce" calc-reduce :transient t)
+    ("a" "apply" calc-apply :transient t)
+    ("A" "accumulate" calc-accumulate :transient t)]
    casual-calc-operators-group]
   casual-calc-navigation-group)
 

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -1,6 +1,6 @@
 ;;; casual-calc.el --- Transient UI for Calc -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -113,11 +113,11 @@
 
   ["Arithmetic"
    :class transient-row
-    ("o" "Rounding›" casual-calc-rounding-tmenu)
-    ("c" "Conversion›" casual-calc-conversions-tmenu)
-    ("T" "Time›" casual-calc-time-tmenu)
-    ("i" "Complex›" casual-calc-complex-number-tmenu)
-    ("R" "Random›" casual-calc-random-number-tmenu)]
+   ("o" "Rounding›" casual-calc-rounding-tmenu)
+   ("c" "Conversion›" casual-calc-conversions-tmenu)
+   ("T" "Time›" casual-calc-time-tmenu)
+   ("i" "Complex›" casual-calc-complex-number-tmenu)
+   ("R" "Random›" casual-calc-random-number-tmenu)]
 
   ["Functions"
    [("t" "Trigonometric›" casual-calc-trig-tmenu)

--- a/lisp/casual-calendar-constants.el
+++ b/lisp/casual-calendar-constants.el
@@ -139,12 +139,5 @@ plain ASCII-range string."
      :description (lambda () (casual-calendar-unicode-get :redraw))
      :transient t)]])
 
-;; Transient menu navigation group for calendar.
-(transient-define-group casual-calendar--menu-navigation-group
-  [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
-
 (provide 'casual-calendar-constants)
 ;;; casual-calendar-constants.el ends here

--- a/lisp/casual-calendar-settings.el
+++ b/lisp/casual-calendar-settings.el
@@ -77,10 +77,10 @@ Customize settings for Calendar and Diary modes."
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-calendar-about :transient nil)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-calendar-about :transient nil)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (defun casual-calendar--customize-calendar-group ()
   "Customize calendar group."

--- a/lisp/casual-calendar-utils.el
+++ b/lisp/casual-calendar-utils.el
@@ -43,7 +43,7 @@ by this menu."
     ("i" "ISO Date…" calendar-iso-goto-date :transient t)
     ("d" "Day of Year…" calendar-goto-day-of-year :transient t)]]
 
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-conversions-tmenu ()
   "Casual Calendar Conversions Menu.
@@ -84,13 +84,13 @@ specific supported non-Gregorian calendar system behavior."
    ("A" "Convert to all" calendar-print-other-dates :transient t)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("I" "ⓘ Other Calendars" (lambda ()
-                   (interactive)
-                   (calendar-exit)
-                   (info "(emacs) Other Calendars")))
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("I" "ⓘ Other Calendars" (lambda ()
+                                     (interactive)
+                                     (calendar-exit)
+                                     (info "(emacs) Other Calendars")))
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (transient-define-prefix casual-calendar-lunar-tmenu ()
   "Casual Calendar Lunar (Chinese) Calendar Menu.
@@ -134,7 +134,7 @@ menu `casual-calendar-settings-tmenu'."
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-astro-tmenu ()
   "Casual Calendar Astronomical calendar menu.
@@ -163,7 +163,7 @@ To convert a Astronomical date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-islamic-tmenu ()
   "Casual Calendar Islamic calendar menu.
@@ -205,7 +205,7 @@ menu `casual-calendar-settings-tmenu'."
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-hebrew-tmenu ()
   "Casual Calendar Hebrew calendar menu.
@@ -248,7 +248,7 @@ menu `casual-calendar-settings-tmenu'."
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-bahai-tmenu ()
   "Casual Calendar Bahá’í calendar menu.
@@ -291,7 +291,7 @@ menu `casual-calendar-settings-tmenu'."
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-ethiopic-tmenu ()
   "Casual Calendar Ethiopic calendar menu.
@@ -320,7 +320,7 @@ To convert an Ethiopic date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-french-tmenu ()
   "Casual Calendar French Revolutionary calendar menu.
@@ -349,7 +349,7 @@ To convert a French Revolutionary date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-julian-tmenu ()
   "Casual Calendar Julian calendar menu.
@@ -378,7 +378,7 @@ To convert a Julian date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-coptic-tmenu ()
   "Casual Calendar Coptic calendar menu.
@@ -407,7 +407,7 @@ To convert a Coptic date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-persian-tmenu ()
   "Casual Calendar Persian calendar menu.
@@ -436,7 +436,7 @@ To convert a Persian date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-calendar-mayan-tmenu ()
   "Casual Calendar Mayan calendar menu.
@@ -465,7 +465,7 @@ To convert a Mayan date to Gregorian:
     ("s" "Show all" diary-show-all-entries)]]
 
   casual-calendar--navigation-group
-  casual-calendar--menu-navigation-group)
+  casual-lib-navigation-group-with-return)
 
 (provide 'casual-calendar-utils)
 ;;; casual-calendar-utils.el ends here

--- a/lisp/casual-calendar.el
+++ b/lisp/casual-calendar.el
@@ -87,19 +87,19 @@ Main menu for `calendar' commands.
      :transient t)]]
 
   ["Region"
-    :class transient-row
-    ("C-SPC" "Set Mark" calendar-set-mark :transient t)
-    ("=" "Count Days" calendar-count-days-region :transient t)]
+   :class transient-row
+   ("C-SPC" "Set Mark" calendar-set-mark :transient t)
+   ("=" "Count Days" calendar-count-days-region :transient t)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings›" casual-calendar-settings-tmenu)
-   ("I" "ⓘ" (lambda ()
-              (interactive)
-              (calendar-exit)
-              (calendar-goto-info-node)))
-   ("RET" "Done" transient-quit-all)
-   ("q" "Quit" calendar-exit)])
+          (casual-lib-quit-one)
+          ("," "Settings›" casual-calendar-settings-tmenu)
+          ("I" "ⓘ" (lambda ()
+                     (interactive)
+                     (calendar-exit)
+                     (calendar-goto-info-node)))
+          ("RET" "Done" transient-quit-all)
+          ("q" "Quit" calendar-exit)])
 
 (provide 'casual-calendar)
 ;;; casual-calendar.el ends here

--- a/lisp/casual-compile-settings.el
+++ b/lisp/casual-compile-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-compile-settings.el --- Casual Compile Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -52,9 +52,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-compile-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-compile-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-compile--customize-group ()
   "Customize Compilefile group."

--- a/lisp/casual-compile-utils.el
+++ b/lisp/casual-compile-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-compile-utils.el --- Casual Compile Utils -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025, 2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -59,7 +59,7 @@ plain ASCII-range string."
   "Predicate if compilation is running."
   (let ((buffer (compilation-find-buffer)))
     (if (get-buffer-process buffer)
-	t
+        t
       nil)))
 
 (provide 'casual-compile-utils)

--- a/lisp/casual-compile.el
+++ b/lisp/casual-compile.el
@@ -1,6 +1,6 @@
 ;;; casual-compile.el --- Transient UI for Compilation Mode -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025, 2026  Charles Choi
+;; Copyright (C) 2025-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -129,11 +129,11 @@
     ]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   (casual-lib-quit-all)
-   ("," "Settings›" casual-compile-settings-tmenu)
-   ("J" "Jump to Bookmark…" bookmark-jump)
-   ("q" "Quit" quit-window)])
+          (casual-lib-quit-one)
+          (casual-lib-quit-all)
+          ("," "Settings›" casual-compile-settings-tmenu)
+          ("J" "Jump to Bookmark…" bookmark-jump)
+          ("q" "Quit" quit-window)])
 
 (provide 'casual-compile)
 ;;; casual-compile.el ends here

--- a/lisp/casual-css-settings.el
+++ b/lisp/casual-css-settings.el
@@ -41,9 +41,9 @@
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-css-about)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-css-about)
+          (casual-lib-quit-all)])
 
 (defun casual-css--customize-indent-offset ()
   "Customize CSS `css-indent-offset'."

--- a/lisp/casual-css.el
+++ b/lisp/casual-css.el
@@ -64,10 +64,10 @@ Transient menu to commands provided by `css-mode'."
      :transient t)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-css-settings-tmenu)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-css-settings-tmenu)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (provide 'casual-css)
 ;;; casual-css.el ends here

--- a/lisp/casual-csv-settings.el
+++ b/lisp/casual-csv-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-csv-settings.el --- Casual CSV Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -31,11 +31,11 @@
    ["Customize"
     ("A" "Align Style" casual-csv--customize-align-style
      :description (lambda () (format "Align Style (%s)"
-                                (capitalize (symbol-name csv-align-style)))))
+                                     (capitalize (symbol-name csv-align-style)))))
     ("s" "Separators" casual-csv--customize-separators)
     ("i" "Invisibility Default" casual-csv--customize-invisibility-default
      :description (lambda () (casual-lib-checkbox-label csv-invisibility-default
-                                                   "Invisibility Default")))]
+                                                        "Invisibility Default")))]
 
    [""
     ("G" "CSV Group" casual-csv--customize-group)
@@ -43,12 +43,12 @@
      :description (lambda () (format "Header Lines (%d)" csv-header-lines)))
     ("c" "Comment Start Default" casual-csv--customize-comment-start-default
      :description (lambda () (format
-                         "Comment Start Default (%s)"
-                         csv-comment-start-default)))
+                              "Comment Start Default (%s)"
+                              csv-comment-start-default)))
     ("f" "Field Quotes" casual-csv--customize-field-quotes
      :description (lambda () (format
-                         "Field Quotes (%s)"
-                         (string-join csv-field-quotes))))]
+                              "Field Quotes (%s)"
+                              (string-join csv-field-quotes))))]
 
    ["Width"
     ("w" "Min" casual-csv--customize-align-min-width
@@ -57,13 +57,13 @@
      :description (lambda () (format "Max (%d)" csv-align-max-width)))]]
 
   [:class transient-row
-   (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)]
+          (casual-lib-customize-unicode)
+          (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-csv-about)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-csv-about)
+          (casual-lib-quit-all)])
 
 
 ;; -------------------------------------------------------------------

--- a/lisp/casual-csv-utils.el
+++ b/lisp/casual-csv-utils.el
@@ -86,9 +86,9 @@ plain ASCII-range string."
 (transient-define-prefix casual-csv-align-tmenu ()
   ["Align"
    :description (lambda () (format
-                       "Casual CSV Align: %s %s"
-                       (buffer-name)
-                       (capitalize (symbol-name csv-align-style))))
+                            "Casual CSV Align: %s %s"
+                            (buffer-name)
+                            (capitalize (symbol-name csv-align-style))))
    :class transient-row
    ("a" "Auto" casual-csv-align-auto :transient t)
    ("l" "Left" casual-csv-align-left :transient t)

--- a/lisp/casual-csv.el
+++ b/lisp/casual-csv.el
@@ -51,11 +51,11 @@
   :refresh-suffixes t
   ["Casual CSV"
    :description (lambda () (format
-                       "Casual CSV: %s [%d,%d] %s"
-                       (buffer-name)
-                       (line-number-at-pos)
-                       (csv--field-index)
-                       (capitalize (symbol-name csv-align-style))))
+                            "Casual CSV: %s [%d,%d] %s"
+                            (buffer-name)
+                            (line-number-at-pos)
+                            (csv--field-index)
+                            (capitalize (symbol-name csv-align-style))))
    :pad-keys t
 
    ["Navigation"
@@ -126,11 +126,11 @@
      :inapt-if-not use-region-p)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-csv-settings-tmenu)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)
-   ("q" "Quit" quit-window)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-csv-settings-tmenu)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)
+          ("q" "Quit" quit-window)])
 
 (provide 'casual-csv)
 ;;; casual-csv.el ends here

--- a/lisp/casual-dired-settings.el
+++ b/lisp/casual-dired-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-dired-settings.el --- Casual Dired Settings  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -44,18 +44,18 @@
     ("T" "Use System Trash Can"
      casual-dired--customize-delete-by-moving-to-trash
      :description (lambda ()
-                   (casual-lib-checkbox-label
-                    delete-by-moving-to-trash
-                    "Use System Trash Can"))
+                    (casual-lib-checkbox-label
+                     delete-by-moving-to-trash
+                     "Use System Trash Can"))
      :transient nil)
     (casual-lib-customize-unicode)
     (casual-lib-customize-hide-navigation)
     ("R" "Rename via VC"
      casual-dired--customize-dired-vc-rename-file
      :description (lambda ()
-                   (casual-lib-checkbox-label
-                    dired-vc-rename-file
-                    "Rename via VC"))
+                    (casual-lib-checkbox-label
+                     dired-vc-rename-file
+                     "Rename via VC"))
      :transient nil)
 
     ("v" "Visit Truename"
@@ -80,17 +80,17 @@
     ("p" "Allow Changing Permissions"
      casual-dired--customize-wdired-allow-to-change-permissions
      :description (lambda ()
-                   (casual-lib-checkbox-label
-                    wdired-allow-to-change-permissions
-                    "Allow Changing Permissions"))
+                    (casual-lib-checkbox-label
+                     wdired-allow-to-change-permissions
+                     "Allow Changing Permissions"))
      :transient nil)
 
     ("L" "Allow Redirecting Links"
      casual-dired--customize-wdired-allow-to-redirect-links
      :description (lambda ()
-                   (casual-lib-checkbox-label
-                    wdired-allow-to-redirect-links
-                    "Allow Redirecting Links"))
+                    (casual-lib-checkbox-label
+                     wdired-allow-to-redirect-links
+                     "Allow Redirecting Links"))
      :transient nil)]
 
    ["Dired"
@@ -142,7 +142,7 @@ Switches passed to ‘ls’ for Dired.  MUST contain the ‘l’ option."
   (customize-variable 'dired-listing-switches))
 
 (defun casual-dired--customize-dired-vc-rename-file ()
-    "Customize `dired-vc-rename-file'.
+  "Customize `dired-vc-rename-file'.
 
 This variable configures whether Dired should register file
 renaming in underlying vc system."

--- a/lisp/casual-dired-sort-by.el
+++ b/lisp/casual-dired-sort-by.el
@@ -1,6 +1,6 @@
 ;;; cc-dired-sort-by.el --- Dired Sort By            -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: unix, tools
@@ -85,9 +85,7 @@ This function requires GNU ls from coreutils installed."
 
     ("s" "Size" casual-dired--sort-by-size :transient nil)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (defun casual-dired--sort-by-name ()
   "Sort directory by name.

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-dired-utils.el --- Casual Dired Utils Menu  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -63,20 +63,18 @@ ASCII-range string."
     ("e" "Emacs Lisp›" casual-dired-elisp-tmenu :transient nil)
     ("l" "Link›" casual-dired-link-tmenu :transient nil)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 ;;;###autoload (autoload 'casual-dired-search-replace-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-search-replace-tmenu ()
   ["Search & Replace"
    ["Search in Files"
-     :pad-keys t
-     ("C-s" "I-search…" dired-do-isearch)
-     ("M-s" "I-search regexp…" dired-do-isearch-regexp)
-     ("s" "Search first regexp match…" dired-do-search)]
+    :pad-keys t
+    ("C-s" "I-search…" dired-do-isearch)
+    ("M-s" "I-search regexp…" dired-do-isearch-regexp)
+    ("s" "Search first regexp match…" dired-do-search)]
    ["Replace in Files"
-     ("r" "Query regexp and replace…" dired-do-query-replace-regexp)]]
+    ("r" "Query regexp and replace…" dired-do-query-replace-regexp)]]
 
   ["grep-style regex"
    [("g" "Find regex…" dired-do-find-regexp)
@@ -84,9 +82,7 @@ ASCII-range string."
 
    [("f" "Find in files (rgrep)…" rgrep)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (transient-define-prefix casual-dired-elisp-tmenu ()
   ["Emacs Lisp"

--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -214,9 +214,7 @@
    ("d" "Files For Deletion…" dired-flag-files-regexp :transient nil)
    ("C" "Files To Copy…" dired-do-copy-regexp :transient nil)
    ("r" "Files To Rename…" dired-do-rename-regexp :transient nil)]
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (transient-define-prefix casual-dired-change-tmenu ()
   ["Change"
@@ -224,9 +222,7 @@
     ("G" "Group…" dired-do-chgrp :transient t)
     ("O" "Owner…" dired-do-chown :transient t)]
    [("T" "Touch" dired-do-touch :transient t)]]
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 ;;; Functions
 (defun casual-dired-image-file-p ()

--- a/lisp/casual-ediff-settings.el
+++ b/lisp/casual-ediff-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-ediff-settings.el --- Casual Ediff Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -31,7 +31,7 @@
    [("k" "Keep Variants"
      casual-ediff-customize-ediff-keep-variants
      :description (lambda () (casual-lib-checkbox-label ediff-keep-variants
-                                                   "Keep Variants")))
+                                                        "Keep Variants")))
 
     ("w" "Window Setup Function"
      casual-ediff-customize-ediff-window-setup-function)
@@ -44,9 +44,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-ediff-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-ediff-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-ediff-customize-group ()
   "Customize Ediff group."

--- a/lisp/casual-ediff-utils.el
+++ b/lisp/casual-ediff-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-ediff-utils.el --- Casual Eshell Utils -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025, 2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -112,9 +112,9 @@ the current buffer."
   (when (and (bound-and-true-p buffer-file-name)
              (vc-registered (buffer-file-name)))
     (if (and (buffer-modified-p)
-	     (yes-or-no-p (format "Buffer %s is modified.  Save buffer? " ; if the user prefers y-or-no-p, the should yet use-short-answers, but otherwise you shouldn't force short answers on them 
-				  (buffer-name))))
-      (save-buffer (current-buffer)))
+             (yes-or-no-p (format "Buffer %s is modified.  Save buffer? " ; if the user prefers y-or-no-p, the should yet use-short-answers, but otherwise you shouldn't force short answers on them
+                                  (buffer-name))))
+        (save-buffer (current-buffer)))
     (message buffer-file-name)
     (casual-ediff--internal-last-revision))
 

--- a/lisp/casual-ediff.el
+++ b/lisp/casual-ediff.el
@@ -1,6 +1,6 @@
 ;;; casual-ediff.el --- Transient UI for Eshell -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025  Charles Y. Choi
+;; Copyright (C) 2025-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -51,21 +51,21 @@
   [["A"
     :pad-keys t
     :description (lambda () (casual-ediff--buffer-description
-                        ediff-buffer-A
-                        "A"
-                        (not ediff-buffer-C)))
+                             ediff-buffer-A
+                             "A"
+                             (not ediff-buffer-C)))
     ("ab" "A→B" ediff-copy-A-to-B
      :transient t
      :if (lambda () (and
-                (not ediff-buffer-C)
-                ediff-buffer-B
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-B)))))
+                     (not ediff-buffer-C)
+                     ediff-buffer-B
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-B)))))
 
     ("ac" "A→C" ediff-copy-A-to-C
      :transient t
      :if (lambda () (and
-                ediff-buffer-C
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-C)))))
+                     ediff-buffer-C
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-C)))))
 
     ("ra" "Restore A"
      (lambda ()
@@ -74,8 +74,8 @@
        (casual-ediff--restore-and-save-diff ?a))
      :transient t
      :if (lambda () (and
-                (or ediff-buffer-B ediff-buffer-C)
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
+                     (or ediff-buffer-B ediff-buffer-C)
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
 
     ("wa" "Save A"
      (lambda ()
@@ -84,8 +84,8 @@
        (casual-ediff--save-buffer ?a))
      :transient t
      :if (lambda () (and
-                (or ediff-buffer-B ediff-buffer-C)
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-A))))
+                     (or ediff-buffer-B ediff-buffer-C)
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-A))))
      :inapt-if-not (lambda () (buffer-modified-p ediff-buffer-A)))]
 
    ;; !!!: A diff B
@@ -125,13 +125,13 @@
     ("ba" "A←B" ediff-copy-B-to-A
      :transient t
      :if (lambda () (and
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
 
     ("bc" "B→C" ediff-copy-B-to-C
      :transient t
      :if (lambda () (and
-                ediff-buffer-C
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-C)))))
+                     ediff-buffer-C
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-C)))))
 
     ("rb" "Restore B"
      (lambda ()
@@ -140,10 +140,10 @@
        (casual-ediff--restore-and-save-diff ?b))
      :transient t
      :if (lambda () (and
-                ediff-buffer-B
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
-                (not (string= (file-name-extension (buffer-name ediff-buffer-B))
-                              "~{index}")))))
+                     ediff-buffer-B
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
+                     (not (string= (file-name-extension (buffer-name ediff-buffer-B))
+                                   "~{index}")))))
 
     ("wb" "Save B"
      (lambda ()
@@ -152,9 +152,9 @@
        (casual-ediff--save-buffer ?b))
      :transient t
      :if (lambda () (and
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
-                (not (string= (file-name-extension (buffer-name ediff-buffer-B))
-                              "~{index}"))))
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
+                     (not (string= (file-name-extension (buffer-name ediff-buffer-B))
+                                   "~{index}"))))
      :inapt-if-not (lambda () (buffer-modified-p ediff-buffer-B)))]
 
    ;; !!!: A B diff C
@@ -194,14 +194,14 @@
     ("cb" "B←C" ediff-copy-C-to-B
      :transient t
      :if (lambda () (and
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
-                (not (string= (file-name-extension (buffer-name ediff-buffer-B))
-                              "~{index}")))))
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-B))
+                     (not (string= (file-name-extension (buffer-name ediff-buffer-B))
+                                   "~{index}")))))
 
     ("ca" "A←C" ediff-copy-C-to-A
      :transient t
      :if (lambda () (and
-                (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
+                     (not (casual-ediff--buffer-read-only-p ediff-buffer-A)))))
 
     ("mab" "Merge A,B to C" casual-ediff-copy-AB-to-C
      :transient t
@@ -244,11 +244,11 @@ reply with no."
              nil)))]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("i" "Status" ediff-status-info)
-   ("I" "ⓘ" ediff-documentation)
-   ("," "Settings" casual-ediff-settings-tmenu)
-   ("q" "Quit Ediff" ediff-quit)])
+          (casual-lib-quit-one)
+          ("i" "Status" ediff-status-info)
+          ("I" "ⓘ" ediff-documentation)
+          ("," "Settings" casual-ediff-settings-tmenu)
+          ("q" "Quit Ediff" ediff-quit)])
 
 ;;;###autoload (autoload 'casual-ediff-install "casual-ediff" nil t)
 (defun casual-ediff-install ()

--- a/lisp/casual-editkit-constants.el
+++ b/lisp/casual-editkit-constants.el
@@ -66,10 +66,10 @@ plain ASCII-range string."
 ;; Transient navigation group for Casual EditKit menus.
 (transient-define-group casual-editkit-navigation-group
   [:class transient-row
-   (casual-lib-quit-one)
-   ("U" "Undo" undo :transient t)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("U" "Undo" undo :transient t)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 ;; Transient cursor navigation group for Casual EditKit menus.
 (transient-define-group casual-editkit-cursor-navigation-group

--- a/lisp/casual-editkit-settings.el
+++ b/lisp/casual-editkit-settings.el
@@ -107,10 +107,10 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-editkit-about :transient nil)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-editkit-about :transient nil)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (defun casual-editkit-about-editkit ()
   "Casual EditKit is a user interface library for Emacs editing commands.

--- a/lisp/casual-editkit-utils.el
+++ b/lisp/casual-editkit-utils.el
@@ -186,10 +186,10 @@ Commands pertaining to project operations can be accessed here."
 
   ["Project"
    :class transient-row
-    ("s" "Switch…" project-switch-project)
-    ("b" "List buffers" project-list-buffers)
-    ("k" "Kill buffers" project-kill-buffers)
-    ("F" "Forget" project-forget-project)]
+   ("s" "Switch…" project-switch-project)
+   ("b" "List buffers" project-list-buffers)
+   ("k" "Kill buffers" project-kill-buffers)
+   ("F" "Forget" project-forget-project)]
 
   casual-editkit-navigation-group)
 
@@ -204,7 +204,7 @@ Commands pertaining to editing operations can be accessed here."
     ("k" "Kill (Cut)›" casual-editkit-kill-tmenu
      :if-not casual-editkit-buffer-read-only-p)
     ("y" "Yank (Paste)" yank
-    :if-not (lambda () buffer-read-only))]
+     :if-not (lambda () buffer-read-only))]
 
    [("t" "Transpose›" casual-editkit-transpose-tmenu
      :if-not casual-editkit-buffer-read-only-p)
@@ -240,7 +240,7 @@ Commands pertaining to editing operations can be accessed here."
 
 ;;;###autoload (autoload 'casual-editkit-emoji-symbols-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-emoji-symbols-tmenu ()
-    "Menu for ‘Emoji & Symbols’ commands.
+  "Menu for ‘Emoji & Symbols’ commands.
 
 Commands pertaining to insert character operations can be
 accessed here. Included are commands for smart quotes and
@@ -574,7 +574,7 @@ accessed here."
 
 ;;;###autoload (autoload 'casual-editkit-bookmarks-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-bookmarks-tmenu ()
-    "Menu for ‘Bookmarks’ commands.
+  "Menu for ‘Bookmarks’ commands.
 
 Commands pertaining to bookmark operations can be
 accessed here."
@@ -615,7 +615,7 @@ accessed here."
 
 ;;;###autoload (autoload 'casual-editkit-tools-tmenu "casual-editkit-utils" nil t)
 (transient-define-prefix casual-editkit-tools-tmenu ()
-    "Menu for ‘Tools’ commands.
+  "Menu for ‘Tools’ commands.
 
 Commands pertaining to invoking different tools can be accessed here."
   ["Tools"
@@ -633,8 +633,8 @@ Commands pertaining to invoking different tools can be accessed here."
     ("cc" "Calc" calc)
     ("re" "RE-Builder" re-builder)
     ("wc" "Word Count" (lambda ()
-                        (interactive)
-                        (call-interactively #'count-words)))]
+                         (interactive)
+                         (call-interactively #'count-words)))]
 
    ["Almanac"
     :pad-keys t
@@ -808,15 +808,15 @@ accessed here."
 
   ["Configure"
    ("a" "Auto-fill Mode" auto-fill-mode
-     :description (lambda ()
-                    (casual-lib-checkbox-label auto-fill-function "Auto-fill Mode")))
+    :description (lambda ()
+                   (casual-lib-checkbox-label auto-fill-function "Auto-fill Mode")))
    ("d" "Double Space" casual-editkit--customize-sentence-end-double-space
-     :description (lambda ()
-                    (casual-lib-checkbox-label sentence-end-double-space "Double Space Sentences")))
+    :description (lambda ()
+                   (casual-lib-checkbox-label sentence-end-double-space "Double Space Sentences")))
 
    ("C" "Fill Column" set-fill-column
-     :description (lambda ()
-                    (format "Fill Column (%d)" fill-column)))]
+    :description (lambda ()
+                   (format "Fill Column (%d)" fill-column)))]
   casual-editkit-navigation-group)
 
 ;;;###autoload (autoload 'casual-editkit-narrow-tmenu "casual-editkit-utils" nil t)
@@ -997,7 +997,7 @@ that supports the arguments ‘--backward’ and ‘--regexp’."
             (call-interactively #'search-backward-regexp)
           (call-interactively #'search-backward))
       (if regexp
-            (call-interactively #'search-forward-regexp)
+          (call-interactively #'search-forward-regexp)
         (call-interactively #'search-forward)))))
 
 
@@ -1032,7 +1032,7 @@ that supports the arguments ‘--backward’ and ‘--regexp’."
             (call-interactively #'isearch-backward-regexp)
           (call-interactively #'isearch-backward))
       (if regexp
-            (call-interactively #'isearch-forward-regexp)
+          (call-interactively #'isearch-forward-regexp)
         (call-interactively #'isearch-forward)))))
 
 

--- a/lisp/casual-editkit.el
+++ b/lisp/casual-editkit.el
@@ -122,13 +122,13 @@ user-customized menu."
   ;; casual-editkit-cursor-navigation-group
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("r" "Registers›" casual-editkit-registers-tmenu)
-   ("U" "Undo" undo :transient t)
-   ("," "Settings›" casual-editkit-settings-tmenu)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)
-   ("x" "Exit Emacs" save-buffers-kill-emacs)])
+          (casual-lib-quit-one)
+          ("r" "Registers›" casual-editkit-registers-tmenu)
+          ("U" "Undo" undo :transient t)
+          ("," "Settings›" casual-editkit-settings-tmenu)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)
+          ("x" "Exit Emacs" save-buffers-kill-emacs)])
 
 (provide 'casual-editkit)
 ;;; casual-editkit.el ends here

--- a/lisp/casual-elisp-settings.el
+++ b/lisp/casual-elisp-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-elisp-settings.el --- Casual Elisp Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -32,9 +32,9 @@
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-elisp-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-elisp-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-elisp-about-elisp ()
   "Casual Elisp is a Transient menu for `emacs-lisp-mode'.

--- a/lisp/casual-elisp.el
+++ b/lisp/casual-elisp.el
@@ -101,10 +101,10 @@
      :transient t)]] ; "⤵("
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings›" casual-elisp-settings-tmenu)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings›" casual-elisp-settings-tmenu)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (provide 'casual-elisp)
 ;;; casual-elisp.el ends here

--- a/lisp/casual-eshell-settings.el
+++ b/lisp/casual-eshell-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-eshell-settings.el --- Casual Eshell Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -32,9 +32,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-eshell-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-eshell-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-eshell--customize-group ()
   "Customize Eshell group."

--- a/lisp/casual-eshell.el
+++ b/lisp/casual-eshell.el
@@ -53,7 +53,7 @@
     :if-not buffer-narrowed-p
     ("B" "#<buffer >…" eshell-insert-buffer-name)
     ("k" "Clear" eshell-kill-input
-    :description (lambda () (casual-eshell-unicode-get :clear)))
+     :description (lambda () (casual-eshell-unicode-get :clear)))
     ("h" "History" eshell-list-history)]
 
    ["Argument"
@@ -107,10 +107,10 @@
    ("Pq" "Quit" eshell-quit-process)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("i" "ⓘ›" casual-eshell-info-tmenu)
-   ("," "Settings›" casual-eshell-settings-tmenu)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("i" "ⓘ›" casual-eshell-info-tmenu)
+          ("," "Settings›" casual-eshell-settings-tmenu)
+          (casual-lib-quit-all)])
 
 (transient-define-prefix casual-eshell-info-tmenu ()
   "Menu for Eshell Info."
@@ -133,9 +133,7 @@
     ("R" "Redirection" casual-eshell-info-redirection)
     ("p" "Pipelines" casual-eshell-info-pipelines)]]
 
-  [:class transient-row
-   (casual-lib-quit-one)
-   (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (provide 'casual-eshell)
 ;;; casual-eshell.el ends here

--- a/lisp/casual-eww-settings.el
+++ b/lisp/casual-eww-settings.el
@@ -44,15 +44,15 @@
    ["Display"
     ("f" "Use Fonts" casual-eww--customize-shr-use-fonts
      :description (lambda () (casual-lib-checkbox-label
-                         shr-use-fonts "Use Fonts"))
+                              shr-use-fonts "Use Fonts"))
      :transient t)
     ("c" "Use Colors" casual-eww--customize-shr-use-colors
      :description (lambda () (casual-lib-checkbox-label
-                         shr-use-colors "Use Colors"))
+                              shr-use-colors "Use Colors"))
      :transient t)
     ("i" "Inhibit Images" casual-eww--customize-shr-inhibit-images
      :description (lambda () (casual-lib-checkbox-label
-                         shr-inhibit-images "Inhibit Images"))
+                              shr-inhibit-images "Inhibit Images"))
      :transient t)]]
 
   ["General"
@@ -61,10 +61,10 @@
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-eww-about :transient nil)
-   ("G" "EWW Group" casual-eww--customize-group)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-eww-about :transient nil)
+          ("G" "EWW Group" casual-eww--customize-group)
+          (casual-lib-quit-all)])
 
 (defun casual-eww--customize-group ()
   "Customize EWW group."

--- a/lisp/casual-eww-utils.el
+++ b/lisp/casual-eww-utils.el
@@ -114,9 +114,7 @@ Note that only the runtime value of variables is changed. Commands in
                      (t "Undefined"))))
     :transient t)]
 
-  [:class transient-row
-   (casual-lib-quit-one)
-   (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 
 

--- a/lisp/casual-eww.el
+++ b/lisp/casual-eww.el
@@ -69,91 +69,94 @@
 EWW (Emacs Web Wowser) is a web browser for GNU Emacs.
 
 See Info node `(eww)Top' for more information on it."
-   :refresh-suffixes t
-   ["Casual EWW"
-    ["History"
-     :pad-keys t
-     ("M-[" "❬" eww-back-url
-      :description (lambda () (casual-eww-unicode-get :history-back))
-      :transient t)
-     ("M-]" "❭" eww-forward-url
-      :description (lambda () (casual-eww-unicode-get :history-forward))
-      :transient t)
-     ("H" "History" eww-list-histories
-      :description (lambda () (casual-eww-unicode-get :history))
-      :transient nil)]
-
-    ["Document"
-     ("[" "←" eww-previous-url
-      :description (lambda () (casual-eww-unicode-get :back))
-      :transient t)
-     ("]" "→" eww-next-url
-      :description (lambda () (casual-eww-unicode-get :forward))
-      :transient t)
-     ("^" "↑" eww-up-url
-      :description (lambda () (casual-eww-unicode-get :up))
-      :transient t)
-     ("t" "⤒" eww-top-url
-      :description (lambda () (casual-eww-unicode-get :top))
-      :transient t)]
-
-    ["Navigate"
-     :pad-keys t
-     ("p" "↑ ¶" casual-lib-browse-backward-paragraph
-      :description (lambda () (casual-eww-unicode-get :backward-paragraph))
-      :transient t)
-     ("n" "↓ ¶" casual-lib-browse-forward-paragraph
-      :description (lambda () (casual-eww-unicode-get :forward-paragraph))
-      :transient t)
-     ("SPC" "↓ 📄" scroll-up-command
-      :description (lambda () (casual-eww-unicode-get :scroll-up))
-      :transient t)
-     ("S-SPC" "↑ 📄" scroll-down-command
-      :description (lambda () (casual-eww-unicode-get :scroll-down))
-      :transient t)]
-
-    ["🔗"
-     :description (lambda () (casual-eww-unicode-get :link))
-     :pad-keys t
-     ("k" "↑" shr-previous-link
-      :description (lambda () (casual-eww-unicode-get :previous))
-      :transient t)
-     ("j" "↓" shr-next-link
-      :description (lambda () (casual-eww-unicode-get :next))
-      :transient t)
-     ("RET" "🚀" eww-follow-link
-      :description (lambda () (casual-eww-unicode-get :follow))
-      :transient t)]
-
-    ["Misc"
-     :pad-keys t
-     ("D" "Display›" casual-eww-display-tmenu)
-     ("R" "Readable" eww-readable)]]
-
-   ["URL"
+  :refresh-suffixes t
+  ["Casual EWW"
+   ["History"
     :pad-keys t
-    [("M-l" "Open…" eww)
-     ("&" "Open External…" eww-browse-with-external-browser)]
-    [("c" "Copy" eww-copy-page-url)
-     ("A" "Copy Alt" eww-copy-alternate-url)]
-    [("d" "Download" eww-download)
-     ("g" "Reload" eww-reload
-      :description (lambda () (casual-eww-unicode-get :reload)))]]
+    ("M-[" "❬" eww-back-url
+     :description (lambda () (casual-eww-unicode-get :history-back))
+     :transient t)
+    ("M-]" "❭" eww-forward-url
+     :description (lambda () (casual-eww-unicode-get :history-forward))
+     :transient t)
+    ("H" "History" eww-list-histories
+     :description (lambda () (casual-eww-unicode-get :history))
+     :transient nil)]
 
-   ["EWW Bookmarks"
-    :class transient-row
-    ("b" "Add" eww-add-bookmark)
-    ("B" "List" eww-list-bookmarks)
-    ("M-n" "Next" eww-next-bookmark :transient t)
-    ("M-p" "Previous" eww-previous-bookmark :transient t)]
+   ["Document"
+    ("[" "←" eww-previous-url
+     :description (lambda () (casual-eww-unicode-get :back))
+     :transient t)
+    ("]" "→" eww-next-url
+     :description (lambda () (casual-eww-unicode-get :forward))
+     :transient t)
+    ("^" "↑" eww-up-url
+     :description (lambda () (casual-eww-unicode-get :up))
+     :transient t)
+    ("t" "⤒" eww-top-url
+     :description (lambda () (casual-eww-unicode-get :top))
+     :transient t)]
 
-   [:class transient-row
-    (casual-lib-quit-one)
-    ("," "Settings›" casual-eww-settings-tmenu)
-    ("I" "ⓘ" casual-eww-info)
-    ("J" "Jump to Bookmark…" bookmark-jump)
-    ("q" "Quit" quit-window)
-    (casual-lib-quit-all)])
+   ["Navigate"
+    :pad-keys t
+    ("p" "↑ ¶" casual-lib-browse-backward-paragraph
+     :description (lambda () (casual-eww-unicode-get :backward-paragraph))
+     :transient t)
+    ("n" "↓ ¶" casual-lib-browse-forward-paragraph
+     :description (lambda () (casual-eww-unicode-get :forward-paragraph))
+     :transient t)
+    ("SPC" "↓ 📄" scroll-up-command
+     :description (lambda () (casual-eww-unicode-get :scroll-up))
+     :transient t)
+    ("S-SPC" "↑ 📄" scroll-down-command
+     :description (lambda () (casual-eww-unicode-get :scroll-down))
+     :transient t)]
+
+   ["🔗"
+    :description (lambda () (casual-eww-unicode-get :link))
+    :pad-keys t
+    ("k" "↑" shr-previous-link
+     :description (lambda () (casual-eww-unicode-get :previous))
+     :transient t)
+    ("j" "↓" shr-next-link
+     :description (lambda () (casual-eww-unicode-get :next))
+     :transient t)
+    ("RET" "🚀" eww-follow-link
+     :description (lambda () (casual-eww-unicode-get :follow))
+     :transient t)]
+
+   ["Misc"
+    :pad-keys t
+    ("D" "Display›" casual-eww-display-tmenu)
+    ("R" "Readable" eww-readable)]]
+
+  ["URL"
+   :pad-keys t
+   [("M-l" "Open…" eww)
+    ("&" "Open External…" eww-browse-with-external-browser)]
+   [("c" "Copy" eww-copy-page-url)
+    ("A" "Copy Alt" eww-copy-alternate-url)]
+   [("d" "Download" eww-download)
+    ("g" "Reload" eww-reload
+     :description (lambda () (casual-eww-unicode-get :reload)))]]
+
+  ["EWW Bookmarks"
+   :class transient-row
+   ("b" "Add" eww-add-bookmark)
+   ("B" "List" eww-list-bookmarks)
+   ("M-n" "Next" eww-next-bookmark :transient t)
+   ("M-p" "Previous" eww-previous-bookmark :transient t)]
+
+  [:class transient-row
+          ("C-g" "Back" transient-quit-one
+           :description casual-lib--quit-one-suffix-label
+           :if-not casual-lib-hide-navigation-p)
+          ("," "Settings›" casual-eww-settings-tmenu)
+          ("I" "ⓘ" casual-eww-info)
+          ("J" "Jump to Bookmark…" bookmark-jump)
+          ("q" "Quit" quit-window)
+          ("C-q" "Dismiss" transient-quit-all
+           :if-not casual-lib-quit-all-hide-navigation-p)])
 
 ;;;###autoload (autoload 'casual-eww-bookmarks-tmenu "casual-eww" nil t)
 (transient-define-prefix casual-eww-bookmarks-tmenu ()
@@ -172,9 +175,9 @@ See Info node `(eww)Top' for more information on it."
     ("n" "Next" next-line :transient t)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("q" "Quit" quit-window)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("q" "Quit" quit-window)
+          (casual-lib-quit-all)])
 
 (provide 'casual-eww)
 ;;; casual-eww.el ends here

--- a/lisp/casual-help-settings.el
+++ b/lisp/casual-help-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-help-settings.el --- Casual Help Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -34,9 +34,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-help-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-help-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-help--customize-group ()
   "Customize Helpfile group."

--- a/lisp/casual-help.el
+++ b/lisp/casual-help.el
@@ -126,11 +126,11 @@
      :if casual-help--symbolp)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-help-settings-tmenu)
-   ("J" "Jump to Bookmark…" bookmark-jump)
-   ("q" "Quit" quit-window)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-help-settings-tmenu)
+          ("J" "Jump to Bookmark…" bookmark-jump)
+          ("q" "Quit" quit-window)
+          (casual-lib-quit-all)])
 
 (provide 'casual-help)
 ;;; casual-help.el ends here

--- a/lisp/casual-html-settings.el
+++ b/lisp/casual-html-settings.el
@@ -36,7 +36,7 @@
     ("t" "Tree-sitter Basic" casual-html--customize-html-ts-mode-indent-offset
      :if (lambda () (derived-mode-p 'html-ts-mode))
      :description (lambda () (format "Tree-sitter Basic (%d)"
-                                html-ts-mode-indent-offset)))
+                                     html-ts-mode-indent-offset)))
     ("A" "Attribute" casual-html--customize-sgml-attribute-offset
      :description (lambda () (format "Attribute (%d)" sgml-attribute-offset)))]
 
@@ -49,9 +49,9 @@
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-html-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-html-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-html--customize-group-sgml ()
   "Customize SGML group."

--- a/lisp/casual-html.el
+++ b/lisp/casual-html.el
@@ -61,8 +61,8 @@ For more documentation, refer to the following links:
   :refresh-suffixes t
   ["Casual HTML"
    :description (lambda () (if (derived-mode-p 'html-ts-mode)
-                          "Casual HTML (Tree-sitter)"
-                        "Casual HTML"))
+                               "Casual HTML (Tree-sitter)"
+                             "Casual HTML"))
 
    ["</>"
     :inapt-if (lambda () (if buffer-read-only t nil))
@@ -83,11 +83,11 @@ For more documentation, refer to the following links:
     ("v" "Validate" sgml-validate)
     ("A" "Autoview" html-autoview-mode
      :description (lambda () (casual-lib-checkbox-label html-autoview-mode
-                                                   "HTML Autoview"))
+                                                        "HTML Autoview"))
      :if (lambda () (derived-mode-p 'html-mode)))
     ("TAB" "Toggle Invisible Tags" sgml-tags-invisible
      :description (lambda () (casual-lib-checkbox-label sgml-tags-invisible
-                                             "Invisible Tags"))
+                                                        "Invisible Tags"))
      :transient t)]
 
    ["Navigation"
@@ -101,11 +101,11 @@ For more documentation, refer to the following links:
     ("C-n" "↓" next-line :transient t)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-html-settings-tmenu)
-   ("I" "ⓘ" casual-html-info)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-html-settings-tmenu)
+          ("I" "ⓘ" casual-html-info)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 
 ;;;###autoload (autoload 'casual-html-tags-tmenu "casual-html" nil t)
@@ -164,10 +164,7 @@ This menu provides an interface to HTML-specific commands provided by
    ("h5" "5" html-headline-5)
    ("h6" "6" html-headline-6)]
 
-  [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 (provide 'casual-html)
 ;;; casual-html.el ends here

--- a/lisp/casual-ibuffer-filter.el
+++ b/lisp/casual-ibuffer-filter.el
@@ -1,6 +1,6 @@
 ;;; casual-ibuffer-filter.el --- Casual IBuffer Filter -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -50,7 +50,7 @@ The value from `ibuffer-saved-filter-groups' is used."
 
   (setq casual-ibuffer--current-collection-name name)
   (setq ibuffer-filter-groups (cdr (assoc name ibuffer-saved-filter-groups))
-	ibuffer-hidden-filter-groups nil)
+        ibuffer-hidden-filter-groups nil)
   (ibuffer-update nil t))
 
 (defun casual-ibuffer--ibuffer-update (arg &optional silent)
@@ -163,14 +163,17 @@ The value from `ibuffer-saved-filter-groups' is used."
     ("\\" "Clear all" ibuffer-clear-filter-groups :transient t)]]
 
   [:class transient-row
-          (casual-lib-quit-one)
+          ("C-g" "Back" transient-quit-one
+           :description casual-lib--quit-one-suffix-label
+           :if-not casual-lib-hide-navigation-p)
           ("," "Settings›" casual-ibuffer-settings-tmenu)
           ("RET" "Visit/Toggle" casual-ibuffer-return-dwim)
           ("$" "Toggle Group" ibuffer-toggle-filter-group
            :description (lambda () (format "Toggle %s" (casual-ibuffer-unicode-get :group)))
            :inapt-if-not (lambda () (casual-ibuffer-filter-group-p))
            :transient t)
-          (casual-lib-quit-all)])
+          ("C-q" "Dismiss" transient-quit-all
+           :if-not casual-lib-quit-all-hide-navigation-p)])
 
 (provide 'casual-ibuffer-filter)
 ;;; casual-ibuffer-filter.el ends here

--- a/lisp/casual-ibuffer-settings.el
+++ b/lisp/casual-ibuffer-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-ibuffer-settings.el --- Casual IBuffer Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -31,11 +31,11 @@
   "Casual IBuffer settings menu."
   ["IBuffer: Settings"
    ["Customize"
-   ("f" "Saved Filters" casual-ibuffer--customize-ibuffer-saved-filters)
-   ("g" "Saved Filter Groups" casual-ibuffer--customize-ibuffer-saved-filter-groups)
-   ("G" "IBuffer Group" casual-ibuffer--customize-group)
-   (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)]]
+    ("f" "Saved Filters" casual-ibuffer--customize-ibuffer-saved-filters)
+    ("g" "Saved Filter Groups" casual-ibuffer--customize-ibuffer-saved-filter-groups)
+    ("G" "IBuffer Group" casual-ibuffer--customize-group)
+    (casual-lib-customize-unicode)
+    (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
           ("a" "About" casual-ibuffer-about :transient nil)

--- a/lisp/casual-ibuffer.el
+++ b/lisp/casual-ibuffer.el
@@ -150,8 +150,8 @@
           (casual-lib-quit-one)
           ("RET" "Visit/Toggle" casual-ibuffer-return-dwim
            :description (lambda () (if (casual-ibuffer-filter-group-p)
-                               "Toggle"
-                             "Visit")))
+                                       "Toggle"
+                                     "Visit")))
           ("," "Settings›" casual-ibuffer-settings-tmenu)
           ("J" "Jump to Bookmark…" bookmark-jump :transient nil)
           (casual-lib-quit-all)
@@ -171,9 +171,7 @@
    [("T" "Toggle Read-only" ibuffer-do-toggle-read-only)
     ("L" "Toggle Lock" ibuffer-do-toggle-lock)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 ;;;###autoload (autoload 'casual-ibuffer-sortby-tmenu "casual-ibuffer" nil t)
 (transient-define-prefix casual-ibuffer-sortby-tmenu ()

--- a/lisp/casual-image-settings.el
+++ b/lisp/casual-image-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-image-settings.el --- Casual Image Settings  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025  Charles Choi
+;; Copyright (C) 2025-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -37,10 +37,7 @@
     (casual-lib-customize-unicode)
     (casual-lib-customize-hide-navigation)]]
 
-  [:class transient-row
-   (casual-lib-quit-one)
-   ;; ("a" "About" casual-info-about :transient nil)
-   (casual-lib-quit-all)])
+  casual-lib-navigation-group-plain)
 
 (defun casual-image--customize-group ()
   "Customize Image group."

--- a/lisp/casual-image-utils.el
+++ b/lisp/casual-image-utils.el
@@ -198,10 +198,10 @@ Menu resizing an image."
 
    ["Options"
     ("g" "Geometry" "--geometry="
-    :always-read t
-    :allow-empty nil
-    :summary "ImageMagick geometry specifier."
-    :prompt "Geometry: ")
+     :always-read t
+     :allow-empty nil
+     :summary "ImageMagick geometry specifier."
+     :prompt "Geometry: ")
     ("o" "Output to another file" "--as"
      :summary "If enabled, then specify output file.")
 
@@ -212,10 +212,7 @@ Menu resizing an image."
   ["Command"
    ("r" "Resize" casual-image--resize :transient t)]
 
-  [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 (provide 'casual-image-utils)
 ;;; casual-image-utils.el ends here

--- a/lisp/casual-image.el
+++ b/lisp/casual-image.el
@@ -109,12 +109,12 @@
     ("w" "Copy filename" image-mode-copy-file-name-as-kill :transient t)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("I" "Identify" casual-image--indentify-verbose)
-   ("," "Settings›" casual-image-settings-tmenu)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)
-   ("q" "Quit View" quit-window)])
+          (casual-lib-quit-one)
+          ("I" "Identify" casual-image--indentify-verbose)
+          ("," "Settings›" casual-image-settings-tmenu)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)
+          ("q" "Quit View" quit-window)])
 
 
 (provide 'casual-image)

--- a/lisp/casual-info-settings.el
+++ b/lisp/casual-info-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-info-settings.el --- Casual Info Settings  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools

--- a/lisp/casual-info.el
+++ b/lisp/casual-info.el
@@ -1,6 +1,6 @@
 ;;; casual-info.el --- Transient UI for Info -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -79,21 +79,21 @@
    ["Scroll"
     :pad-keys t
     ("S-SPC" "Scroll Down" Info-scroll-down
-           :if display-graphic-p
-           :description (lambda ()
+     :if display-graphic-p
+     :description (lambda ()
                     (casual-info-unicode-get :scroll-down))
-           :transient t)
+     :transient t)
 
     ("DEL" "Scroll Down" Info-scroll-down
-           :if-not display-graphic-p
-           :description (lambda ()
+     :if-not display-graphic-p
+     :description (lambda ()
                     (casual-info-unicode-get :scroll-down))
-           :transient t)
+     :transient t)
 
     ("SPC" "Scroll Up" Info-scroll-up
-           :description (lambda ()
+     :description (lambda ()
                     (casual-info-unicode-get :scroll-up))
-           :transient t)]]
+     :transient t)]]
 
   ["Navigation"
    ["Link"

--- a/lisp/casual-isearch-settings.el
+++ b/lisp/casual-isearch-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-isearch-settings.el --- Casual Re-Builder Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -30,29 +30,29 @@
   "Casual I-Search settings menu."
   :refresh-suffixes t
   ["I-Search: Settings"
-    ["Allow"
-     ("s" "Scroll" casual-isearch--customize-allow-scroll)
-     ("m" "Motion" casual-isearch--customize-allow-motion
-      :description (lambda ()
-                     (casual-lib-checkbox-label isearch-allow-motion "Motion")))]
+   ["Allow"
+    ("s" "Scroll" casual-isearch--customize-allow-scroll)
+    ("m" "Motion" casual-isearch--customize-allow-motion
+     :description (lambda ()
+                    (casual-lib-checkbox-label isearch-allow-motion "Motion")))]
 
-    ["Lazy"
-     ("h" "Highlight" casual-isearch--customize-lazy-highlight)
-     ("c" "Count" casual-isearch--customize-lazy-count
-      :description (lambda ()
-                     (casual-lib-checkbox-label isearch-lazy-count "Count")))]
+   ["Lazy"
+    ("h" "Highlight" casual-isearch--customize-lazy-highlight)
+    ("c" "Count" casual-isearch--customize-lazy-count
+     :description (lambda ()
+                    (casual-lib-checkbox-label isearch-lazy-count "Count")))]
 
-    ["Misc"
-     ("G" "Group" casual-isearch--customize-group)]]
-
-  [:class transient-row
-   (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)]
+   ["Misc"
+    ("G" "Group" casual-isearch--customize-group)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-isearch-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-customize-unicode)
+          (casual-lib-customize-hide-navigation)]
+
+  [:class transient-row
+          (casual-lib-quit-one)
+          ("a" "About" casual-isearch-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-isearch--customize-group ()
   "Customize I-Search group."

--- a/lisp/casual-isearch.el
+++ b/lisp/casual-isearch.el
@@ -1,6 +1,6 @@
 ;;; casual-isearch.el --- Transient UI for I-Search -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2024-2025  Charles Y. Choi
+;; Copyright (C) 2023-2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: wp
@@ -64,32 +64,32 @@
     ("X" "Regexp searching (edit)"
      isearch-toggle-regexp
      :description (lambda () (casual-lib-checkbox-label isearch-regexp
-                                                   "Regexp search")))
+                                                        "Regexp search")))
 
     ("S" "Symbol searching (edit)"
      isearch-toggle-symbol
      :description (lambda () (casual-lib-checkbox-label
-                         (eq isearch-regexp-function #'isearch-symbol-regexp)
-                         "Symbol search")))
+                              (eq isearch-regexp-function #'isearch-symbol-regexp)
+                              "Symbol search")))
 
     ("W" "Word searching (edit)"
      isearch-toggle-word
      :description (lambda () (casual-lib-checkbox-label
-                         (eq isearch-regexp-function #'word-search-regexp)
-                         "Word search")))
+                              (eq isearch-regexp-function #'word-search-regexp)
+                              "Word search")))
 
     ("F" "Case fold"
      isearch-toggle-case-fold
      :description (lambda () (casual-lib-checkbox-label
-                         isearch-case-fold-search
-                         "Case insensitive")))
+                              isearch-case-fold-search
+                              "Case insensitive")))
     ("L" "Lax whitespace"
      isearch-toggle-lax-whitespace
      :description (lambda () (casual-lib-checkbox-label
-                         (if isearch-regexp
-                             isearch-regexp-lax-whitespace
-                           isearch-lax-whitespace)
-                         "Lax whitespace")))]
+                              (if isearch-regexp
+                                  isearch-regexp-lax-whitespace
+                                isearch-lax-whitespace)
+                              "Lax whitespace")))]
 
    ["Misc"
     ("o" "Occur" isearch-occur)

--- a/lisp/casual-ispell-settings.el
+++ b/lisp/casual-ispell-settings.el
@@ -36,9 +36,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-ispell-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-ispell-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-ispell--customize-group ()
   "Customize Ispell group."

--- a/lisp/casual-ispell.el
+++ b/lisp/casual-ispell.el
@@ -54,8 +54,8 @@
     ("b" "Buffer" ispell-buffer)]
 
    [:if (lambda () (funcall casual-ispell-comment-or-string-predicate))
-    ("s" "String/Comment" ispell-comment-or-string-at-point)
-    ("c" "Comments & Strings" ispell-comments-and-strings)]
+        ("s" "String/Comment" ispell-comment-or-string-at-point)
+        ("c" "Comments & Strings" ispell-comments-and-strings)]
 
    [("TAB" "Complete Word" ispell-complete-word)
     ("SPC" "Complete Word Fragment" ispell-complete-word-interior-frag)]
@@ -63,12 +63,12 @@
    [("x" "Kill Ispell" ispell-kill-ispell)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-ispell-settings-tmenu)
-   ("I" "ⓘ" casual-ispell-info)
-   ("D" "Change Dictionary…" ispell-change-dictionary)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-ispell-settings-tmenu)
+          ("I" "ⓘ" casual-ispell-info)
+          ("D" "Change Dictionary…" ispell-change-dictionary)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (provide 'casual-ispell)
 ;;; casual-ispell.el ends here

--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -1,6 +1,6 @@
 ;;; casual-lib.el --- Library routines for Casual user interfaces -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -186,7 +186,7 @@ new buffer. This can be avoided if a prefix ARG is provided."
 
 (transient-define-suffix casual-lib-quit-one ()
   "Casual suffix to call `transient-quit-one'."
-  :transient nil
+  :transient #'transient--do-quit-one
   :key "C-g"
   :if-not #'casual-lib-hide-navigation-p
   :description #'casual-lib--quit-one-suffix-label
@@ -195,21 +195,21 @@ new buffer. This can be avoided if a prefix ARG is provided."
 
 (transient-define-group casual-lib-navigation-group-plain
   [:class transient-row
-   (casual-lib-quit-one)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          (casual-lib-quit-all)])
 
 (transient-define-group casual-lib-navigation-group-with-return
   [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (transient-define-group casual-lib-navigation-group-with-undo-and-return
   [:class transient-row
-   (casual-lib-quit-one)
-   ("U" "Undo" undo :transient t)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("U" "Undo" undo :transient t)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (transient-define-suffix casual-lib-customize-unicode ()
   "Customize Casual to use Unicode symbols.

--- a/lisp/casual-make-settings.el
+++ b/lisp/casual-make-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-make-settings.el --- Casual Make Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025, 2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -34,9 +34,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-make-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-make-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-make--customize-group ()
   "Customize Makefile group."

--- a/lisp/casual-man-settings.el
+++ b/lisp/casual-man-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-man-settings.el --- Casual Man Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -37,9 +37,9 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-man-about :transient nil)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-man-about :transient nil)
+          (casual-lib-quit-all)])
 
 (defun casual-man--customize-group ()
   "Customize Manfile group."

--- a/lisp/casual-man.el
+++ b/lisp/casual-man.el
@@ -1,6 +1,6 @@
 ;;; casual-man.el --- Transient UI for Man -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025  Charles Y. Choi
+;; Copyright (C) 2025-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -117,16 +117,16 @@
    ("J" "Jump…" bookmark-jump)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("m" "Man…" man)
-   ("u" "Update" Man-update-manpage
-    :description (lambda () (casual-man-unicode-get :update)))
-   ("," "Settings" casual-man-settings-tmenu)
-   ("I" "ⓘ" casual-man-info)
-   ("K" "Close" Man-kill
-    :description (lambda () (casual-man-unicode-get :kill)))
-   ("q" "Quit" quit-window)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("m" "Man…" man)
+          ("u" "Update" Man-update-manpage
+           :description (lambda () (casual-man-unicode-get :update)))
+          ("," "Settings" casual-man-settings-tmenu)
+          ("I" "ⓘ" casual-man-info)
+          ("K" "Close" Man-kill
+           :description (lambda () (casual-man-unicode-get :kill)))
+          ("q" "Quit" quit-window)
+          (casual-lib-quit-all)])
 
 (provide 'casual-man)
 ;;; casual-man.el ends here

--- a/lisp/casual-org-settings.el
+++ b/lisp/casual-org-settings.el
@@ -172,10 +172,10 @@ Always choose love."
    (casual-lib-customize-hide-navigation)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-org-about :transient nil)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("a" "About" casual-org-about :transient nil)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 (transient-define-prefix casual-org-settings-heading-tmenu ()
   "Customize Org heading settings."
@@ -211,10 +211,10 @@ Always choose love."
    ["Hide"
     ("s" "Leading Stars" casual-org--customize-hide-leading-stars
      :description (lambda () (casual-lib-checkbox-label org-hide-leading-stars
-                                                   "Hide Leading Stars")))
+                                                        "Hide Leading Stars")))
     ("e" "Emphasis Markers" casual-org--customize-hide-emphasis-markers
      :description (lambda () (casual-lib-checkbox-label org-hide-emphasis-markers
-                                                   "Hide Emphasis Markers")))]
+                                                        "Hide Emphasis Markers")))]
    ["Startup"
     ("f" "Folded" casual-org--customize-startup-folded
      :description (lambda () (format "Startup Folded (%s)" org-startup-folded)))
@@ -228,10 +228,10 @@ Always choose love."
   ["Casual Org Settings: Keyboard"
    ("s" "Support Shift Select" casual-org--customize-support-shift-select
     :description (lambda () (casual-lib-checkbox-label org-support-shift-select
-                                                  "Shift Select")))
+                                                       "Shift Select")))
    ("S" "Use Speed Commands" casual-org--customize-use-speed-commands
     :description (lambda () (casual-lib-checkbox-label org-use-speed-commands
-                                                  "Speed Commands")))]
+                                                       "Speed Commands")))]
   casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-org-settings-clock-tmenu ()

--- a/lisp/casual-org-utils.el
+++ b/lisp/casual-org-utils.el
@@ -395,11 +395,11 @@ region."
   (let* ((end-cell (casual-org-table--cell-at-point))
          (start (region-beginning))
          (end (region-end)))
-      (exchange-point-and-mark)
-      (let ((start-cell (casual-org-table--cell-at-point)))
-        (push-mark start nil t)
-        (goto-char end)
-        (list start-cell end-cell))))
+    (exchange-point-and-mark)
+    (let ((start-cell (casual-org-table--cell-at-point)))
+      (push-mark start nil t)
+      (goto-char end)
+      (list start-cell end-cell))))
 
 (defvar casual-org-table--last-reference nil
   "Last stored Org table reference.
@@ -538,9 +538,9 @@ See `casual-org-table--range' for more on RANGE object."
   "Fill table down with count of ROWS."
   (interactive "nRows: ")
   (while (> rows 0)
-      ;;(message "%d" rows)
-      (call-interactively #'org-table-copy-down)
-      (setq rows (1- rows))))
+    ;;(message "%d" rows)
+    (call-interactively #'org-table-copy-down)
+    (setq rows (1- rows))))
 
 (defun casual-org-table-kill-field-as-copy ()
   "Kill field as copy."
@@ -679,18 +679,18 @@ Org 9.8."
     ("Z" "Shrink Table" org-table-shrink :transient t)
     ("t" "Toggle Coordinates" org-table-toggle-coordinate-overlays
      :description (lambda () (casual-lib-checkbox-label
-                         org-table-overlay-coordinates
-                         "@𝑟$𝑐"))
+                              org-table-overlay-coordinates
+                              "@𝑟$𝑐"))
      :transient t)
     ("h" "Header Mode" org-table-header-line-mode
      :description (lambda () (casual-lib-checkbox-label
-                         org-table-header-line-mode
-                         "Header"))
+                              org-table-header-line-mode
+                              "Header"))
      :transient t)
     ("V" "Line Wrap" visual-line-mode
      :description (lambda () (casual-lib-checkbox-label
-                         visual-line-mode
-                         "Line Wrap"))
+                              visual-line-mode
+                              "Line Wrap"))
      :transient t)]])
 
 
@@ -700,7 +700,7 @@ Org 9.8."
    :if (lambda () (and (casual-org-mode-p) (org-at-heading-p)))
    :inapt-if casual-lib-buffer-read-only-p
    :description (lambda () (catch 'casual-org--description-exception
-                        (casual-org--heading-description)))
+                             (casual-org--heading-description)))
    ["Headline"
     :pad-keys t
     ("t" "TODO State…" org-todo)
@@ -737,12 +737,12 @@ Org 9.8."
   ["Org Item"
    :if (lambda () (and (casual-org-mode-p) (org-at-item-p)))
    :description (lambda () (catch 'casual-org--description-exception
-                        (casual-org--item-description)))
+                             (casual-org--item-description)))
 
    ["Item"
     :description (lambda () (if (org-at-item-checkbox-p)
-                           "Checkbox"
-                         "Item"))
+                                "Checkbox"
+                              "Item"))
     :pad-keys t
     :inapt-if casual-lib-buffer-read-only-p
     ("a" "Add" org-insert-item
@@ -753,8 +753,8 @@ Org 9.8."
      :transient t)
     ("b" "Toggle Checkbox" casual-org-toggle-list-to-checkbox
      :description (lambda () (if (org-at-item-checkbox-p)
-                            "To Item"
-                          "To Checkbox"))
+                                 "To Item"
+                               "To Checkbox"))
      :transient t)
     ("c" "Cycle" org-cycle-list-bullet :transient t)]
 
@@ -777,73 +777,73 @@ Org 9.8."
    :if (lambda () (and (casual-org-mode-p) (org-at-block-p)))
    :inapt-if casual-lib-buffer-read-only-p
    :description (lambda () (catch 'casual-org--description-exception
-                        (casual-org--block-description)))
+                             (casual-org--block-description)))
    [("'" "Edit" org-edit-src-code :transient nil)]
    [("n" "Assign Name…" casual-org-assign-name)]
    [("C-c" "Eval" org-ctrl-c-ctrl-c
      :if (lambda () (or (eq (org-element-type (org-element-context)) 'src-block)
-                   (eq (org-element-type (org-element-context)) 'dynamic-block)))
+                        (eq (org-element-type (org-element-context)) 'dynamic-block)))
      :transient t)]])
 
 
 (transient-define-group casual-org-body-group
   ["Org Body"
    :if-not (lambda () (if (casual-org-mode-p)
-                      (or (org-at-heading-or-item-p)
-                          (org-at-table-p)
-                          (org-at-block-p)
-                          (org-at-keyword-p))
-                   t))
+                          (or (org-at-heading-or-item-p)
+                              (org-at-table-p)
+                              (org-at-block-p)
+                              (org-at-keyword-p))
+                        t))
    :description (lambda () (catch 'casual-org--description-exception
-                        (casual-org--body-description)))
+                             (casual-org--body-description)))
    :inapt-if casual-lib-buffer-read-only-p
 
    ;; !!!: Body
    ["To"
     :if-not (lambda () (or (org-at-keyword-p)
-                      (org-at-drawer-p) ; covers property-drawer-p
-                      (org-at-clock-log-p)
-                      (org-in-src-block-p)
-                      (org-at-property-p)))
+                           (org-at-drawer-p) ; covers property-drawer-p
+                           (org-at-clock-log-p)
+                           (org-in-src-block-p)
+                           (org-at-property-p)))
     ("*" "Heading" org-ctrl-c-star :transient t)
     ("-" "Item" org-ctrl-c-minus :transient t)]
 
    ["Add"
     :if-not (lambda () (or (org-at-keyword-p)
-                      (org-at-drawer-p) ; covers property-drawer-p
-                      (org-at-clock-log-p)
-                      (org-in-src-block-p)
-                      (org-at-property-p)))
+                           (org-at-drawer-p) ; covers property-drawer-p
+                           (org-at-clock-log-p)
+                           (org-in-src-block-p)
+                           (org-at-property-p)))
     ("b" "Block…" org-insert-structure-template)
     ("d" "Drawer…" org-insert-drawer)
     ("k" "Keyword…" casual-org-insert-keyword)]
 
    ;; !!!: org-in-src-block-p
    [:if (lambda () (and (casual-org-mode-p) (org-in-src-block-p)))
-    ("'" "Edit" org-edit-src-code :transient nil)]
+        ("'" "Edit" org-edit-src-code :transient nil)]
 
    [:if (lambda () (and (casual-org-mode-p) (org-in-src-block-p)))
-    ("C-c" "Eval" org-ctrl-c-ctrl-c
-     :if (lambda () (or (eq (org-element-type (org-element-context)) 'src-block)
-                   (eq (org-element-type (org-element-context)) 'dynamic-block)))
-     :transient t)]
+        ("C-c" "Eval" org-ctrl-c-ctrl-c
+         :if (lambda () (or (eq (org-element-type (org-element-context)) 'src-block)
+                            (eq (org-element-type (org-element-context)) 'dynamic-block)))
+         :transient t)]
 
    ;; !!!: org-at-property-drawer-p
    [:if (lambda () (and (casual-org-mode-p) (org-at-property-drawer-p)))
-    ("p" "Add Property…" org-set-property)]
+        ("p" "Add Property…" org-set-property)]
 
    ;; !!!: org-at-property-p
    [:if (lambda () (and (casual-org-mode-p) (org-at-property-p)))
-    ("p" "Add Property…" org-set-property)]
+        ("p" "Add Property…" org-set-property)]
 
    [:if (lambda () (and (casual-org-mode-p) (org-at-property-p)))
-    ("a" "Action…" org-property-action)]
+        ("a" "Action…" org-property-action)]
 
    ;; !!!: org-at-drawer-p
    [:if (lambda () (and (casual-org-mode-p)
-                   (org-at-drawer-p)
-                   (not (org-at-property-drawer-p))))
-    ("TAB" "Cycle…" org-cycle :transient t)]
+                        (org-at-drawer-p)
+                        (not (org-at-property-drawer-p))))
+        ("TAB" "Cycle…" org-cycle :transient t)]
 
    ;; !!!: org-at-clock-log-p
    ["Clock"
@@ -870,67 +870,67 @@ Org 9.8."
   ["Org Keyword"
    :if (lambda () (and (casual-org-mode-p) (org-at-keyword-p)))
    :description (lambda () (catch 'casual-org--description-exception
-                        (casual-org--keyword-description)))
+                             (casual-org--keyword-description)))
    :inapt-if casual-lib-buffer-read-only-p
    [:if org-at-TBLFM-p
-    ("F" "Edit Formulas" org-table-edit-formulas :transient nil)]
+        ("F" "Edit Formulas" org-table-edit-formulas :transient nil)]
 
    [:if org-at-TBLFM-p
-    ("C-c" "Eval" org-table-recalculate-buffer-tables :transient nil)]
+        ("C-c" "Eval" org-table-recalculate-buffer-tables :transient nil)]
 
    ;; TODO: Does this apply to all affiliate keywords?
    [:if-not org-at-TBLFM-p
-    :inapt-if (lambda () (org-element-property :key (org-element-context)))
-    ("C-c" "Eval" org-ctrl-c-ctrl-c :transient nil)]])
+            :inapt-if (lambda () (org-element-property :key (org-element-context)))
+            ("C-c" "Eval" org-ctrl-c-ctrl-c :transient nil)]])
 
 
 (transient-define-group casual-org-navigation-group
   [:if casual-org-mode-p
-   ["Field"
-    :if org-at-table-p
-    ("M-a" "⇤" org-table-beginning-of-field
-     :description (lambda () (casual-org-unicode-get :beginning-of-field))
-     :transient t)]
+       ["Field"
+        :if org-at-table-p
+        ("M-a" "⇤" org-table-beginning-of-field
+         :description (lambda () (casual-org-unicode-get :beginning-of-field))
+         :transient t)]
 
-   [""
-    :if org-at-table-p
-    ("M-e" "⇥" org-table-end-of-field
-     :description (lambda () (casual-org-unicode-get :end-of-field))
-     :transient t)]
+       [""
+        :if org-at-table-p
+        ("M-e" "⇥" org-table-end-of-field
+         :description (lambda () (casual-org-unicode-get :end-of-field))
+         :transient t)]
 
-   ["Mark"
-    :if-not (lambda () (or (org-at-keyword-p)
-                      (org-at-table-p)
-                      (org-at-block-p)))
-    ("ms" "Subtree" org-mark-subtree)]
+       ["Mark"
+        :if-not (lambda () (or (org-at-keyword-p)
+                               (org-at-table-p)
+                               (org-at-block-p)))
+        ("ms" "Subtree" org-mark-subtree)]
 
-   [""
-    :if-not (lambda () (or (org-at-keyword-p)
-                      (org-at-table-p)
-                      (org-at-block-p)))
-    ("me" "Element" org-mark-element)]
+       [""
+        :if-not (lambda () (or (org-at-keyword-p)
+                               (org-at-table-p)
+                               (org-at-block-p)))
+        ("me" "Element" org-mark-element)]
 
-   ["Util"
-    ("v" "Copy Visible"
-     org-copy-visible
-     :inapt-if-not (lambda () (use-region-p)))]
-   [""
-    ("e" "Export…" org-export-dispatch)]])
+       ["Util"
+        ("v" "Copy Visible"
+         org-copy-visible
+         :inapt-if-not (lambda () (use-region-p)))]
+       [""
+        ("e" "Export…" org-export-dispatch)]])
 
 
 
 (transient-define-group casual-org-utility-group
   [
    :if-not (lambda () (if (casual-org-mode-p)
-                     (or (org-at-table-p)
-                         (org-at-TBLFM-p)
-                         (org-at-block-p)
-                         (org-at-property-p)
-                         (org-at-drawer-p)
-                         (org-at-clock-log-p)
-                         (org-in-src-block-p)
-                         (org-at-keyword-p))
-                   t))
+                          (or (org-at-table-p)
+                              (org-at-TBLFM-p)
+                              (org-at-block-p)
+                              (org-at-property-p)
+                              (org-at-drawer-p)
+                              (org-at-clock-log-p)
+                              (org-in-src-block-p)
+                              (org-at-keyword-p))
+                        t))
 
    ["Link"
     :inapt-if casual-lib-buffer-read-only-p
@@ -972,19 +972,19 @@ Org 9.8."
      :transient nil)
     ("P" "Toggle Prettify" prettify-symbols-mode
      :description (lambda () (casual-lib-checkbox-label prettify-symbols-mode
-                                                   "Prettify"))
+                                                        "Prettify"))
      :transient nil)]
 
    [""
     :if casual-org-mode-p
     ("V" "Line Wrap" visual-line-mode
      :description (lambda () (casual-lib-checkbox-label visual-line-mode
-                                                   "Line Wrap"))
+                                                        "Line Wrap"))
      :transient t)
     ("N" "Number" org-num-mode
      :if org-at-heading-p
      :description (lambda () (casual-lib-checkbox-label org-num-mode
-                                                   "Heading #"))
+                                                        "Heading #"))
      :transient t)]])
 
 
@@ -1019,29 +1019,29 @@ Org 9.8."
     :inapt-if casual-lib-buffer-read-only-p
     ("M-b" "Column ←" org-table-move-column-left
      :description (lambda () (format "%s %s"
-                                (casual-org-unicode-get :column)
-                                (casual-org-unicode-get :left)))
+                                     (casual-org-unicode-get :column)
+                                     (casual-org-unicode-get :left)))
      :transient t)]
 
    [""
     :inapt-if casual-lib-buffer-read-only-p
     ("M-p" "Row ↑" org-table-move-row-up
      :description (lambda () (format "%s %s"
-                                (casual-org-unicode-get :row)
-                                (casual-org-unicode-get :up)))
+                                     (casual-org-unicode-get :row)
+                                     (casual-org-unicode-get :up)))
      :transient t)
     ("M-n" "Row ↓" org-table-move-row-down
      :description (lambda () (format "%s %s"
-                                (casual-org-unicode-get :row)
-                                (casual-org-unicode-get :down)))
+                                     (casual-org-unicode-get :row)
+                                     (casual-org-unicode-get :down)))
      :transient t)]
 
    [""
     :inapt-if casual-lib-buffer-read-only-p
     ("M-f" "Column →" org-table-move-column-right
      :description (lambda () (format "%s %s"
-                                (casual-org-unicode-get :column)
-                                (casual-org-unicode-get :right)))
+                                     (casual-org-unicode-get :column)
+                                     (casual-org-unicode-get :right)))
      :transient t)]]
 
   ["Align"
@@ -1051,7 +1051,7 @@ Org 9.8."
    ("ar" "Right" casual-org-table-insert-align-right)
    ("I" "Width & Alignment" casual-org-table-info-width-alignment
     :description (lambda () (format "%s Width & Align"
-                               (casual-org-unicode-get :info))))]
+                                    (casual-org-unicode-get :info))))]
 
   ["Field"
    [("M-a" "⇤" org-table-beginning-of-field :transient t)]

--- a/lisp/casual-org.el
+++ b/lisp/casual-org.el
@@ -74,14 +74,14 @@ Emacs key bindings for movement."
   casual-org-navigation-group
 
   [:class transient-row
-   :if casual-org-mode-p
-   (casual-lib-quit-one)
-   ("," "Settings›" casual-org-settings-tmenu)
-   ("I" "ⓘ" casual-org-info
-    :description (lambda () (casual-org-unicode-get :info)))
-   ("U" "Undo" undo :transient t)
-   ("RET" "Done" transient-quit-all)
-   (casual-lib-quit-all)])
+          :if casual-org-mode-p
+          (casual-lib-quit-one)
+          ("," "Settings›" casual-org-settings-tmenu)
+          ("I" "ⓘ" casual-org-info
+           :description (lambda () (casual-org-unicode-get :info)))
+          ("U" "Undo" undo :transient t)
+          ("RET" "Done" transient-quit-all)
+          (casual-lib-quit-all)])
 
 
 ;;;###autoload (autoload 'casual-org-table-fedit-tmenu "casual-org" nil t)

--- a/lisp/casual-re-builder-settings.el
+++ b/lisp/casual-re-builder-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-re-builder-settings.el --- Casual Re-Builder Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025 Charles Y. Choi
+;; Copyright (C) 2024-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -36,10 +36,13 @@
     (casual-lib-customize-hide-navigation)]]
 
   [:class transient-row
-          (casual-lib-quit-one)
+          ("C-g" "Back" transient-quit-one
+           :description casual-lib--quit-one-suffix-label
+           :if-not casual-lib-hide-navigation-p)
           ("a" "About" casual-re-builder-about :transient nil)
 
-          (casual-lib-quit-all)])
+          ("C-q" "Dismiss" transient-quit-all
+           :if-not casual-lib-quit-all-hide-navigation-p)])
 
 (defun casual-re-builder--customize-group ()
   "Customize Re-Builder group."

--- a/lisp/casual-timezone-settings.el
+++ b/lisp/casual-timezone-settings.el
@@ -1,6 +1,6 @@
 ;;; casual-timezone-settings.el --- Casual Timezone Settings -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -50,28 +50,28 @@
                     (format
                      "Convert: (ex: %s)"
                      (format-time-string
-                     casual-timezone-convert-datestamp-format
-                     (current-time)))))
+                      casual-timezone-convert-datestamp-format
+                      (current-time)))))
 
     ("p" "Planner" casual-timezone--customize-datestamp-format
      :description (lambda ()
                     (format
                      "Planner: (ex: %s)"
                      (format-time-string
-                     casual-timezone-datestamp-format
-                     (current-time)))))
+                      casual-timezone-datestamp-format
+                      (current-time)))))
     ("f" "Describe Format" casual-timezone--describe-format-time-string)]]
 
   [:class transient-row
-   (casual-lib-customize-unicode)
-   (casual-lib-customize-hide-navigation)
-   ("D" "Zoneinfo DB" casual-timezone--customize-zone-info-database)]
+          (casual-lib-customize-unicode)
+          (casual-lib-customize-hide-navigation)
+          ("D" "Zoneinfo DB" casual-timezone--customize-zone-info-database)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("a" "About" casual-timezone-about :transient nil)
+          (casual-lib-quit-one)
+          ("a" "About" casual-timezone-about :transient nil)
 
-   (casual-lib-quit-all)])
+          (casual-lib-quit-all)])
 
 (defun casual-timezone--customize-working-hour-glyph ()
   "Set working hour glyph.

--- a/lisp/casual-timezone-utils.el
+++ b/lisp/casual-timezone-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-timezone-utils.el --- Casual Timezone Utils -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Charles Y. Choi
+;; Copyright (C) 2025-2026 Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -164,10 +164,10 @@ The format of the timestamp is defined in the variable
     (error "Not available on Windows"))
 
   (let* ((datestr (or datestr
-                        (org-read-date t nil nil nil nil
-                                       (format-time-string
-                                        "%H:%M"
-                                        (current-time)))))
+                      (org-read-date t nil nil nil nil
+                                     (format-time-string
+                                      "%H:%M"
+                                      (current-time)))))
          (remote-tz (or remote-tz
                         (completing-read-default
                          "Remote Timezone: "
@@ -214,10 +214,10 @@ The format of the timestamp is defined in the variable
                          "Remote Timezone: "
                          (casual-timezone-zone-info))))
          (datestr (or datestr
-                        (org-read-date t nil nil nil nil
-                                       (format-time-string
-                                        "%H:%M"
-                                        (current-time)))))
+                      (org-read-date t nil nil nil nil
+                                     (format-time-string
+                                      "%H:%M"
+                                      (current-time)))))
          (tzcode (casual-timezone-offset-8601
                   (nth 0 (current-time-zone nil remote-tz))))
          (parse-ts (string-split datestr))
@@ -329,25 +329,25 @@ customized via the variable `casual-timezone-working-hours-range'."
     (casual-timezone-planner-mode)
 
     (let ((inhibit-read-only t))
-        (erase-buffer)
-        (make-vtable
-         :columns (append
-                   `((:name ,local-tz :width 30 :align left)) ;; !!! For some reason I can't pass in local-tz
-                   (seq-map (lambda (remote-tz)
-                              `(:name ,remote-tz :width 30 :align left))
-                            remote-timezones))
+      (erase-buffer)
+      (make-vtable
+       :columns (append
+                 `((:name ,local-tz :width 30 :align left)) ;; !!! For some reason I can't pass in local-tz
+                 (seq-map (lambda (remote-tz)
+                            `(:name ,remote-tz :width 30 :align left))
+                          remote-timezones))
 
-         :objects tz-data
+       :objects tz-data
 
-         :getter `(lambda (issue column table)
-                    (nth column issue))
+       :getter `(lambda (issue column table)
+                  (nth column issue))
 
-         :formatter `(lambda (value column table)
-                       (casual-timezone--date-formatter value))
+       :formatter `(lambda (value column table)
+                     (casual-timezone--date-formatter value))
 
-         :displayer `(lambda (fvalue index max-width table)
-                       (propertize fvalue 'default 'bold)))
-        (casual-timezone-jump-to-relative-now))))
+       :displayer `(lambda (fvalue index max-width table)
+                     (propertize fvalue 'default 'bold)))
+      (casual-timezone-jump-to-relative-now))))
 
 
 (defun casual-timezone-planner-current-local ()
@@ -530,10 +530,10 @@ window width has changed."
     ("c" "Calendar" calendar)]]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-timezone-settings-tmenu)
-   ("q" "Quit" quit-window)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-timezone-settings-tmenu)
+          ("q" "Quit" quit-window)
+          (casual-lib-quit-all)])
 
 (provide 'casual-timezone-utils)
 ;;; casual-timezone-utils.el ends here

--- a/lisp/casual-timezone.el
+++ b/lisp/casual-timezone.el
@@ -1,6 +1,6 @@
 ;;; casual-timezone.el --- Timezone Planner  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025  Charles Choi
+;; Copyright (C) 2025-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -36,9 +36,9 @@
    ("z" "Planner…" casual-timezone-planner)]
 
   [:class transient-row
-   (casual-lib-quit-one)
-   ("," "Settings" casual-timezone-settings-tmenu)
-   (casual-lib-quit-all)])
+          (casual-lib-quit-one)
+          ("," "Settings" casual-timezone-settings-tmenu)
+          (casual-lib-quit-all)])
 
 (provide 'casual-timezone)
 ;;; casual-timezone.el ends here


### PR DESCRIPTION
Recent Transient update (commit: 8b14203) broke prior definition of
`casual-lib-quit-one` suffix.

This commit uses guidance from https://github.com/magit/transient/issues/436 to
fix `casual-lib-quit-one` suffix.

Also includes maintenance to indent and whitespace clean the codebase.
