### PR TITLE
Add support for marked file navigation

### DIFF
--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-dired-utils.el --- Casual Dired Utils Menu  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -48,6 +48,30 @@ non-nil, then the Unicode symbol is returned, otherwise a plain
 ASCII-range string."
   (casual-lib-unicode-db-get key casual-dired-unicode-db))
 
+
+(defun casual-dired-marked-p ()
+  "Predicate if Dired item is marked."
+  (if (derived-mode-p 'dired-mode)
+      (char-equal (char-after (line-beginning-position)) dired-marker-char)
+    nil))
+
+(defun casual-dired-marked-files-p ()
+  "Predicate if any marked files are in place."
+  (if (and (derived-mode-p 'dired-mode) (dired-file-name-at-point))
+      (let* ((current (expand-file-name (dired-file-name-at-point)))
+             (files (dired-get-marked-files))
+             (count (length files))
+             (is-current-marked (casual-dired-marked-p)))
+
+        (if (and (eq count 1) (member current files))
+            is-current-marked
+          t))
+    nil))
+
+
+;; -------------------------------------------------------------------
+;; Transients
+
 (transient-define-prefix casual-dired-utils-tmenu ()
   ["Utils - Marked Files or File under Point"
    ["Files"
@@ -63,9 +87,7 @@ ASCII-range string."
     ("e" "Emacs Lisp›" casual-dired-elisp-tmenu :transient nil)
     ("l" "Link›" casual-dired-link-tmenu :transient nil)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 ;;;###autoload (autoload 'casual-dired-search-replace-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-search-replace-tmenu ()
@@ -84,9 +106,7 @@ ASCII-range string."
 
    [("f" "Find in files (rgrep)…" rgrep)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-dired-elisp-tmenu ()
   ["Emacs Lisp"
@@ -100,9 +120,7 @@ ASCII-range string."
    ["Verification"
     ("c" "Check documentation strings" checkdoc-dired :transient nil)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-dired-link-tmenu ()
   ["Link"
@@ -118,9 +136,7 @@ ASCII-range string."
     ("h" "Hard…" dired-do-hardlink)
     ("H" "Hard regexp…" dired-do-hardlink-regexp)]]
 
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 (provide 'casual-dired-utils)
 ;;; casual-dired-utils.el ends here

--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -51,22 +51,24 @@
 (transient-define-prefix casual-dired-tmenu ()
   "Transient menu for Dired."
   :refresh-suffixes t
-  [["File"
-    ("o" "Open Other" dired-find-file-other-window :transient nil)
+
+  [:inapt-if-not-derived 'dired-mode
+   ["File"
+    ("o" "Open Other" dired-find-file-other-window)
     ("v" "View" dired-view-file)
     ("C" "Copy to…" dired-do-copy :transient t)
     ("R" "Rename…" dired-do-rename :transient t)
     ("D" "Delete…" dired-do-delete :transient t)
-    ("l" "Link›" casual-dired-link-tmenu :transient nil)
-    ("c" "Change›" casual-dired-change-tmenu :transient nil)
+    ("l" "Link›" casual-dired-link-tmenu)
+    ("c" "Change›" casual-dired-change-tmenu)
     ("y" "Type" dired-show-file-type :transient t)
-    ("w" "Copy Name" dired-copy-filename-as-kill :transient nil)
-    ("!" "Shell…" dired-do-shell-command :transient nil)
-    ("&" "Shell &… " dired-do-async-shell-command :transient nil)
+    ("w" "Copy Name" dired-copy-filename-as-kill)
+    ("!" "Shell…" dired-do-shell-command)
+    ("&" "Shell &… " dired-do-async-shell-command)
     (";" "Thumbnail" image-dired-dired-toggle-marked-thumbs
      :if display-graphic-p
      :transient t)
-    ("W" "Browse" browse-url-of-dired-file :transient nil)]
+    ("W" "Browse" browse-url-of-dired-file)]
 
    ["Directory"
     ("s" "Sort By›" casual-dired-sort-by-tmenu
@@ -97,16 +99,22 @@
     ("T" "Thumbnails…" image-dired :if display-graphic-p)
     ("d" "Dired…" dired)]
 
-   ["Mark"
-    ("m" "Mark" dired-mark :transient t)
-    ("u" "Unmark" dired-unmark :transient t)
-    ("U" "Unmark All" dired-unmark-all-marks :transient t)
+   ["Bulk"
+    ("m" "Mark" dired-mark
+     :if-not casual-dired-marked-p
+     :transient t)
+    ("u" "Unmark" dired-unmark
+     :if casual-dired-marked-p
+     :transient t)
+    ("U" "Unmark All" dired-unmark-all-marks
+     :if casual-dired-marked-files-p
+     :transient t)
     ("t" "Toggle Marks" dired-toggle-marks :transient t)
+    ("r" "Regexp›" casual-dired-regexp-tmenu)
+    ("/" "Search & Replace›" casual-dired-search-replace-tmenu)
+    ("#" "Utils›" casual-dired-utils-tmenu)
     ("~" "Flag Backups" dired-flag-backup-files :transient t)
-    ("x" "Delete Flagged" dired-do-flagged-delete :transient t)
-    ("r" "Regexp›" casual-dired-regexp-tmenu :transient nil)
-    ("#" "Utils›" casual-dired-utils-tmenu :transient nil)
-    ("/" "Search & Replace›" casual-dired-search-replace-tmenu :transient nil)]
+    ("x" "Delete Flagged" dired-do-flagged-delete :transient t)]
 
    ["Navigation"
     :pad-keys t
@@ -130,6 +138,26 @@
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :down-arrow)
                              casual-lib-use-unicode)
+                            (casual-dired-unicode-get :file)))
+     :transient t)
+    ("M-[" " ↑ *📄" dired-prev-marked-file
+     :if casual-dired-marked-p
+     :description (lambda ()
+                    (format "%s %s%s"
+                            (casual-dired-format-arrow
+                             (casual-dired-unicode-get :up-arrow)
+                             casual-lib-use-unicode)
+                            (char-to-string dired-marker-char)
+                            (casual-dired-unicode-get :file)))
+     :transient t)
+    ("M-]" " ↓ *📄" dired-next-marked-file
+     :if casual-dired-marked-p
+     :description (lambda ()
+                    (format "%s %s%s"
+                            (casual-dired-format-arrow
+                             (casual-dired-unicode-get :down-arrow)
+                             casual-lib-use-unicode)
+                            (char-to-string dired-marker-char)
                             (casual-dired-unicode-get :file)))
      :transient t)
     ("M-p" " ↑ 📁" dired-prev-dirline
@@ -185,15 +213,16 @@
                             (casual-dired-unicode-get :subdir)))
      :transient t)]]
 
-  [["Quick"
-    ("J" "Jump to Bookmark…" bookmark-jump :transient nil)
-    ("B" "Add Bookmark…" bookmark-set-no-overwrite :transient nil)
-    ("b" "List Buffers" ibuffer :transient nil)]
+  [:inapt-if-not-derived 'dired-mode
+   ["Quick"
+    ("J" "Jump to Bookmark…" bookmark-jump)
+    ("B" "Add Bookmark…" bookmark-set-no-overwrite)
+    ("b" "List Buffers" ibuffer)]
 
    ["Search"
     :pad-keys t
-    ("C-s" "I-Search…" dired-isearch-filenames :transient nil)
-    ("M-s" "I-Search Regexp…" dired-isearch-filenames-regexp :transient nil)
+    ("C-s" "I-Search…" dired-isearch-filenames)
+    ("M-s" "I-Search Regexp…" dired-isearch-filenames-regexp)
     ("M-f" "Find in files (rgrep)…" rgrep)]
 
    ["New"
@@ -201,22 +230,33 @@
     ("F" "File" dired-create-empty-file :transient t)]]
 
   [:class transient-row
-          (casual-lib-quit-one)
-          ("RET" "Open" dired-find-file :transient nil)
-          ("," "Settings›" casual-dired-settings-tmenu :transient nil)
-          ("q" "Quit Dired" quit-window)])
+   (casual-lib-quit-one)
+   ("RET" "Open" dired-find-file)
+   ("," "Settings›" casual-dired-settings-tmenu)
+   ("q" "Quit Dired" quit-window)])
 
 (transient-define-prefix casual-dired-regexp-tmenu ()
-  "Transient menu for Dired mark regexp functions."
-  ["Regexp Mark"
-   ("m" "Files…" dired-mark-files-regexp :transient nil)
-   ("c" "Files Containing…" dired-mark-files-containing-regexp :transient nil)
-   ("d" "Files For Deletion…" dired-flag-files-regexp :transient nil)
-   ("C" "Files To Copy…" dired-do-copy-regexp :transient nil)
-   ("r" "Files To Rename…" dired-do-rename-regexp :transient nil)]
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  "Transient menu for Dired regexp functions."
+  :refresh-suffixes t
+  ["Regexp"
+   ["Mark"
+    ("m" "Files…" dired-mark-files-regexp :transient t)
+    ("c" "Files containing…" dired-mark-files-containing-regexp :transient t)
+    ("u" "Unmark" dired-unmark
+     :inapt-if-not casual-dired-marked-p
+     :transient t)
+    ("U" "Unmark All" dired-unmark-all-marks
+     :inapt-if-not casual-dired-marked-files-p
+     :transient t)]
+   ["Operate"
+    ("F" "Files to open…" dired-do-find-marked-files)
+    ("C" "Files to copy…" dired-do-copy-regexp)
+    ("r" "Files to rename…" dired-do-rename-regexp)
+    ("D" "Files to delete…" dired-do-delete)]
+   ["Flag"
+    ("d" "Files for deletion…" dired-flag-files-regexp)
+    ("x" "Delete flagged files" dired-do-flagged-delete)]]
+  casual-lib-navigation-group-with-return)
 
 (transient-define-prefix casual-dired-change-tmenu ()
   ["Change"
@@ -224,9 +264,7 @@
     ("G" "Group…" dired-do-chgrp :transient t)
     ("O" "Owner…" dired-do-chown :transient t)]
    [("T" "Touch" dired-do-touch :transient t)]]
-  [:class transient-row
-          (casual-lib-quit-one)
-          (casual-lib-quit-all)])
+  casual-lib-navigation-group-with-return)
 
 ;;; Functions
 (defun casual-dired-image-file-p ()

--- a/tests/casual-dired-test-utils.el
+++ b/tests/casual-dired-test-utils.el
@@ -1,6 +1,6 @@
 ;;; casual-dired-test-utils.el --- Casual Test Utils       -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -28,9 +28,9 @@
 (require 'transient)
 (require 'kmacro)
 
-(defun casualt-dired-setup ()
-  "Casual menu test setup function."
-  (dired "/tmp"))
+(defun casualt-dired-setup (&optional tmpdir)
+  "Dired test setup function."
+  (dired tmpdir))
 
 (defun casualt-dired-breakdown (&optional clear)
   "Casual menu test breakdown function, if CLEAR is non-nil then clear state."

--- a/tests/test-casual-dired.el
+++ b/tests/test-casual-dired.el
@@ -1,6 +1,6 @@
 ;;; test-casual-dired.el --- Casual Dired Tests      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Y. Choi
+;; Copyright (C) 2024-2026  Charles Y. Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -25,104 +25,233 @@
 ;;; Code:
 
 (require 'ert)
+(require 'casual-lib-test-utils)
 (require 'casual-dired-test-utils)
 (require 'casual-dired)
 
-(ert-deftest test-casual-dired-tmenu-bindings ()
-  (casualt-dired-setup)
+(ert-deftest test-casual-dired-tmenu ()
+  (let ((tmpdir "/usr/share"))
+    (casualt-dired-setup tmpdir)
+    (dired-goto-file "/usr/share/man")
+    (dired-insert-subdir "/usr/share/man")
+    (call-interactively #'dired-mark)
+    (next-line)
 
-  (cl-letf
-      (((symbol-function #'dired-do-shell-command) (lambda (x) (interactive)(print "WARNING: override")))
-       ((symbol-function #'dired-do-async-shell-command) (lambda (x) (interactive)(print "WARNING: override")))
-       ((symbol-function #'image-dired) (lambda (x) (interactive)(print "WARNING: override"))))
+    (cl-letf (;; (symbol-function #'display-graphic-p (lambda (&optional display) t))
+              (casualt-mock #'dired-find-file-other-window)
+              (casualt-mock #'dired-view-file)
+              (casualt-mock #'dired-do-copy)
+              (casualt-mock #'dired-do-rename)
+              (casualt-mock #'dired-do-delete)
+              (casualt-mock #'casual-dired-link-tmenu)
+              (casualt-mock #'casual-dired-change-tmenu)
+              (casualt-mock #'dired-show-file-type)
+              (casualt-mock #'dired-copy-filename-as-kill)
+              (casualt-mock #'dired-do-shell-command)
+              (casualt-mock #'dired-do-async-shell-command)
+              ;; (casualt-mock #'image-dired-dired-toggle-marked-thumbs)
+              (casualt-mock #'browse-url-of-dired-file)
+              (casualt-mock #'casual-dired-sort-by-tmenu)
+              (casualt-mock #'dired-hide-details-mode)
+              (casualt-mock #'dired-omit-mode)
+              (casualt-mock #'dired-maybe-insert-subdir)
+              (casualt-mock #'dired-hide-subdir)
+              (casualt-mock #'dired-do-kill-lines)
+              (casualt-mock #'revert-buffer)
+              (casualt-mock #'casual-dired-find-dired-regexp)
+              (casualt-mock #'wdired-change-to-wdired-mode)
+              ;; (casualt-mock #'image-dired)
+              (casualt-mock #'dired-mark)
+              (casualt-mock #'dired-unmark-all-marks)
+              (casualt-mock #'dired-toggle-marks)
+              (casualt-mock #'dired-flag-backup-files)
+              (casualt-mock #'dired-do-flagged-delete)
+              (casualt-mock #'casual-dired-regexp-tmenu)
+              (casualt-mock #'dired-up-directory)
+              (casualt-mock #'dired-previous-line)
+              (casualt-mock #'dired-next-line)
+              (casualt-mock #'dired-prev-dirline)
+              (casualt-mock #'dired-next-dirline)
+              (casualt-mock #'dired-prev-subdir)
+              (casualt-mock #'dired-next-subdir)
+              (casualt-mock #'dired-goto-file)
+              (casualt-mock #'dired-goto-subdir)
+              (casualt-mock #'bookmark-jump)
+              (casualt-mock #'bookmark-set-no-overwrite)
+              (casualt-mock #'ibuffer)
+              (casualt-mock #'dired-isearch-filenames)
+              (casualt-mock #'dired-isearch-filenames-regexp)
+              (casualt-mock #'casual-dired-search-replace-tmenu)
+              (casualt-mock #'dired-create-directory)
+              (casualt-mock #'dired-create-empty-file)
+              (casualt-mock #'rgrep))
 
-    (let ((test-vectors (list))
-          (dired-use-ls-dired t))
-      (push (casualt-suffix-test-vector "o" #'dired-find-file-other-window) test-vectors)
-      (push (casualt-suffix-test-vector "v" #'dired-view-file) test-vectors)
-      (push (casualt-suffix-test-vector "C" #'dired-do-copy) test-vectors)
-      (push (casualt-suffix-test-vector "R" #'dired-do-rename) test-vectors)
-      (push (casualt-suffix-test-vector "D" #'dired-do-delete) test-vectors)
-      (push (casualt-suffix-test-vector "l" #'casual-dired-link-tmenu) test-vectors)
-      (push (casualt-suffix-test-vector "c" #'casual-dired-change-tmenu) test-vectors)
-      (push (casualt-suffix-test-vector "y" #'dired-show-file-type) test-vectors)
-      (push (casualt-suffix-test-vector "w" #'dired-copy-filename-as-kill) test-vectors)
-      (push (casualt-suffix-test-vector "!" #'dired-do-shell-command) test-vectors)
-      (push (casualt-suffix-test-vector "&" #'dired-do-async-shell-command) test-vectors)
-      (push (casualt-suffix-test-vector "W" #'browse-url-of-dired-file) test-vectors)
+      (let ((test-vectors
+             '((:binding "o" :command dired-find-file-other-window)
+               (:binding "v" :command dired-view-file)
+               (:binding "C" :command dired-do-copy)
+               (:binding "R" :command dired-do-rename)
+               (:binding "D" :command dired-do-delete)
+               (:binding "l" :command casual-dired-link-tmenu)
+               (:binding "c" :command casual-dired-change-tmenu)
+               (:binding "y" :command dired-show-file-type)
+               (:binding "w" :command dired-copy-filename-as-kill)
+               (:binding "!" :command dired-do-shell-command)
+               (:binding "&" :command dired-do-async-shell-command)
+               ;; (:binding ";" :command image-dired-dired-toggle-marked-thumbs)
+               (:binding "W" :command browse-url-of-dired-file)
+               (:binding "s" :command casual-dired-sort-by-tmenu)
+               (:binding "h" :command dired-hide-details-mode)
+               (:binding "O" :command dired-omit-mode)
+               (:binding "i" :command dired-maybe-insert-subdir)
+               (:binding "$" :command dired-hide-subdir)
+               (:binding "k" :command dired-do-kill-lines)
+               (:binding "g" :command revert-buffer)
+               (:binding "f" :command casual-dired-find-dired-regexp)
+               (:binding "E" :command wdired-change-to-wdired-mode)
+               ;; (:binding "T" :command image-dired)
+               (:binding "m" :command dired-mark)
+               (:binding "U" :command dired-unmark-all-marks)
+               (:binding "t" :command dired-toggle-marks)
+               (:binding "~" :command dired-flag-backup-files)
+               (:binding "x" :command dired-do-flagged-delete)
+               (:binding "r" :command casual-dired-regexp-tmenu)
+               (:binding "^" :command dired-up-directory)
+               (:binding "p" :command dired-previous-line)
+               (:binding "n" :command dired-next-line)
+               (:binding "[" :command dired-prev-subdir)
+               (:binding "]" :command dired-next-subdir)
+               (:binding "M-p" :command dired-prev-dirline)
+               (:binding "M-n" :command dired-next-dirline)
+               (:binding "j" :command dired-goto-file)
+               (:binding "M-j" :command dired-goto-subdir)
+               (:binding "J" :command bookmark-jump)
+               (:binding "B" :command bookmark-set-no-overwrite)
+               (:binding "b" :command ibuffer)
+               (:binding "C-s" :command dired-isearch-filenames)
+               (:binding "M-s" :command dired-isearch-filenames-regexp)
+               (:binding "/" :command casual-dired-search-replace-tmenu)
+               (:binding "+" :command dired-create-directory)
+               (:binding "F" :command dired-create-empty-file)
+               (:binding "M-f" :command rgrep))))
 
-      (push (casualt-suffix-test-vector "s" #'casual-dired-sort-by-tmenu) test-vectors)
-      (push (casualt-suffix-test-vector "h" #'dired-hide-details-mode) test-vectors)
-      (push (casualt-suffix-test-vector "O" #'dired-omit-mode) test-vectors)
-      ;; (push (casualt-suffix-test-vector "iq" #'dired-maybe-insert-subdir 2) test-vectors)
-      (push (casualt-suffix-test-vector "$" #'dired-hide-subdir) test-vectors)
-      (push (casualt-suffix-test-vector "k" #'dired-do-kill-lines) test-vectors)
-      (push (casualt-suffix-test-vector "g" #'revert-buffer) test-vectors)
-      (push (casualt-suffix-test-vector "f" #'casual-dired-find-dired-regexp) test-vectors)
-      (push (casualt-suffix-test-vector "E" #'wdired-change-to-wdired-mode) test-vectors)
-      ;; (push (casualt-suffix-test-vector "T" #'image-dired) test-vectors) ; breaks in command line because not display-graphic-p
-      (push (casualt-suffix-test-vector "m" #'dired-mark) test-vectors)
-      (push (casualt-suffix-test-vector "u" #'dired-unmark) test-vectors)
-      (push (casualt-suffix-test-vector "U" #'dired-unmark-all-marks) test-vectors)
-      (push (casualt-suffix-test-vector "t" #'dired-toggle-marks) test-vectors)
-      (push (casualt-suffix-test-vector "~" #'dired-flag-backup-files) test-vectors)
-      (push (casualt-suffix-test-vector "x" #'dired-do-flagged-delete) test-vectors)
-      (push (casualt-suffix-test-vector "r" #'casual-dired-regexp-tmenu) test-vectors)
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-dired-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-dired-breakdown)))
 
-      (push (casualt-suffix-test-vector "^" #'dired-up-directory) test-vectors)
-      (push (casualt-suffix-test-vector "p" #'dired-previous-line) test-vectors)
-      (push (casualt-suffix-test-vector "n" #'dired-next-line) test-vectors)
-      (push (casualt-suffix-test-vector "ð" #'dired-prev-dirline) test-vectors)
-      (push (casualt-suffix-test-vector "î" #'dired-next-dirline) test-vectors)
-      (push (casualt-suffix-test-vector "j" #'dired-goto-file) test-vectors)
-      (push (casualt-suffix-test-vector "ê" #'dired-goto-subdir) test-vectors)
-      ;;(push (casualt-suffix-test-vector "[" #'dired-prev-subdir) test-vectors)
-      ;;(push (casualt-suffix-test-vector "]" #'dired-next-subdir) test-vectors)
+(ert-deftest test-casual-dired-tmenu-image ()
+  (when (display-graphic-p)
+    (let ((tmpdir "/usr/share"))
+      (casualt-dired-setup tmpdir)
+      (dired-goto-file "/usr/share/man")
+      (dired-insert-subdir "/usr/share/man")
 
-      (push (casualt-suffix-test-vector "J" #'bookmark-jump) test-vectors)
-      (push (casualt-suffix-test-vector "B" #'bookmark-set-no-overwrite) test-vectors)
-      (push (casualt-suffix-test-vector "b" #'ibuffer) test-vectors)
+      (cl-letf ((casualt-mock #'image-dired-dired-toggle-marked-thumbs)
+                (casualt-mock #'image-dired))
 
-      ;;(push (casualt-suffix-test-vector "" dired-isearch-filenames) test-vectors)
-      (push (casualt-suffix-test-vector "ó" #'dired-isearch-filenames-regexp) test-vectors)
-      (push (casualt-suffix-test-vector "/" #'casual-dired-search-replace-tmenu) test-vectors)
+        (let ((test-vectors
+               '((:binding ";" :command image-dired-dired-toggle-marked-thumbs)
+                 (:binding "T" :command image-dired))))
 
-      ;;(push (casualt-suffix-test-vector "+q" #'dired-create-directory) test-vectors)
-      (push (casualt-suffix-test-vector "F" #'dired-create-empty-file) test-vectors)
-      (push (casualt-suffix-test-vector "æ" #'rgrep) test-vectors)
+          (casualt-suffix-testcase-runner test-vectors
+                                          #'casual-dired-tmenu
+                                          '(lambda () (random 5000)))))
+      (casualt-dired-breakdown))))
 
-      (casualt-suffix-testbench-runner test-vectors
-                                       #'casual-dired-tmenu
-                                       '(lambda () (random 5000)))))
-  (casualt-dired-breakdown t))
+(ert-deftest test-casual-dired-tmenu-unmark ()
+  (let ((tmpdir "/usr/share"))
+    (casualt-dired-setup tmpdir)
+    (dired-goto-file "/usr/share/man")
+    (dired-insert-subdir "/usr/share/man")
+    (call-interactively #'dired-mark)
+    (previous-line)
+
+    (cl-letf ((casualt-mock #'dired-unmark))
+
+      (let ((test-vectors
+             '((:binding "u" :command dired-unmark))))
+
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-dired-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-dired-breakdown)))
+
+(ert-deftest test-casual-dired-regexp-tmenu ()
+  (let ((tmpdir "/usr/share"))
+    (casualt-dired-setup tmpdir)
+    (dired-goto-file "/usr/share/man")
+    (dired-insert-subdir "/usr/share/man")
+    (call-interactively #'dired-mark)
+    (previous-line)
+
+    (cl-letf ((casualt-mock #'dired-mark-files-regexp)
+              (casualt-mock #'dired-mark-files-containing-regexp)
+              (casualt-mock #'dired-do-find-marked-files)
+              (casualt-mock #'dired-do-copy-regexp)
+              (casualt-mock #'dired-do-rename-regexp)
+              (casualt-mock #'dired-do-delete)
+              (casualt-mock #'dired-flag-files-regexp)
+              (casualt-mock #'dired-do-flagged-delete))
+
+      (let ((test-vectors
+             '((:binding "m" :command dired-mark-files-regexp)
+               (:binding "c" :command dired-mark-files-containing-regexp)
+               (:binding "F" :command dired-do-find-marked-files)
+               (:binding "C" :command dired-do-copy-regexp)
+               (:binding "D" :command dired-do-delete)
+               (:binding "r" :command dired-do-rename-regexp)
+               (:binding "d" :command dired-flag-files-regexp)
+               (:binding "x" :command dired-do-flagged-delete))))
+
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-dired-regexp-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-dired-breakdown)))
+
+(ert-deftest test-casual-dired-regexp-unmark ()
+  (let ((tmpdir "/usr/share"))
+    (casualt-dired-setup tmpdir)
+    (dired-goto-file "/usr/share/man")
+    (dired-insert-subdir "/usr/share/man")
+    (call-interactively #'dired-mark)
+    (previous-line)
+
+    (cl-letf ((casualt-mock #'dired-unmark)
+              (casualt-mock #'dired-unmark-all-marks))
+
+      (let ((test-vectors
+             '((:binding "u" :command dired-unmark)
+               (:binding "U" :command dired-unmark-all-marks))))
+
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-dired-regexp-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-dired-breakdown)))
 
 
-(ert-deftest test-casual-dired-regexp-tmenu-bindings ()
-  (casualt-dired-setup)
-  (let ((test-vectors (list)))
-    (push (casualt-suffix-test-vector "m" #'dired-mark-files-regexp) test-vectors)
-    (push (casualt-suffix-test-vector "c" #'dired-mark-files-containing-regexp) test-vectors)
-    (push (casualt-suffix-test-vector "d" #'dired-flag-files-regexp) test-vectors)
-    (push (casualt-suffix-test-vector "C" #'dired-do-copy-regexp) test-vectors)
-    (push (casualt-suffix-test-vector "r" #'dired-do-rename-regexp) test-vectors)
+(ert-deftest test-casual-dired-change-tmenu ()
+  (let ((tmpdir "/usr/share"))
+    (casualt-dired-setup tmpdir)
+    (dired-goto-file "/usr/share/man")
+    (dired-insert-subdir "/usr/share/man")
+    (next-line)
 
-    (casualt-suffix-testbench-runner test-vectors
-                                     #'casual-dired-regexp-tmenu
-                                     '(lambda () (random 5000))))
-  (casualt-dired-breakdown t))
+    (cl-letf ((casualt-mock #'dired-do-chmod)
+              (casualt-mock #'dired-do-chgrp)
+              (casualt-mock #'dired-do-chown)
+              (casualt-mock #'dired-do-touch))
 
-(ert-deftest test-casual-dired-change-tmenu-bindings ()
-  (casualt-dired-setup)
-  (let ((test-vectors (list)))
-    (push (casualt-suffix-test-vector "M" #'dired-do-chmod) test-vectors)
-    (push (casualt-suffix-test-vector "G" #'dired-do-chgrp) test-vectors)
-    (push (casualt-suffix-test-vector "O" #'dired-do-chown) test-vectors)
-    (push (casualt-suffix-test-vector "T" #'dired-do-touch) test-vectors)
+      (let ((test-vectors
+             '((:binding "M" :command dired-do-chmod)
+               (:binding "G" :command dired-do-chgrp)
+               (:binding "O" :command dired-do-chown)
+               (:binding "T" :command dired-do-touch))))
 
-    (casualt-suffix-testbench-runner test-vectors
-                                     #'casual-dired-change-tmenu
-                                     '(lambda () (random 5000))))
-  (casualt-dired-breakdown t))
+        (casualt-suffix-testcase-runner test-vectors
+                                        #'casual-dired-change-tmenu
+                                        '(lambda () (random 5000)))))
+    (casualt-dired-breakdown)))
 
 
 (ert-deftest test-casual-dired-format-arrow ()


### PR DESCRIPTION
Support marked file navigation via ‘M-[’ and ‘M-]’.
Also reorganize casual-dired-regexp-tmenu

* lisp/casual-dired.el (casual-dired-tmenu):
  - Add dired-prev-marked-file
  - Add dired-next-marked-file

* lisp/casual-dired.el (casual-dired-regexp-tmenu):
  - Reorganize menu
  - Add dired-do-find-marked-files
  - Add dired-do-flagged-delete
  - Add dired-unmark
  - Add dired-unmark-all-marks
  - Add dired-do-delete

* Update documentation

* Update unit tests
