### PR TITLE
Fix predicate casual-dired-marked-p

### DIFF
--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -51,7 +51,8 @@ ASCII-range string."
 
 (defun casual-dired-marked-p ()
   "Predicate if Dired item is marked."
-  (if (derived-mode-p 'dired-mode)
+  (if (and (derived-mode-p 'dired-mode)
+           (> (- (line-end-position) (line-beginning-position)) 0))
       (char-equal (char-after (line-beginning-position)) dired-marker-char)
     nil))
 


### PR DESCRIPTION
* lisp/casual-dired-utils.el (casual-dired-marked-p): Change predicate to
account for when the point is in a blank line to test if the Dired item is
marked.
