### PR TITLE
Merge development to main 20260609_093757

### DIFF
--- a/docs/casual.org
+++ b/docs/casual.org
@@ -5,7 +5,7 @@
 #+EMAIL: kickingvegas@gmail.com
 #+OPTIONS: ':t toc:t author:t email:t H:4 f:t
 #+LANGUAGE: en
-#+MACRO: version 2.16.1
+#+MACRO: version 2.16.2-rc.1
 #+MACRO: kbd (eval (org-texinfo-kbd-macro $1))
 #+TEXINFO_FILENAME: casual.info
 #+TEXINFO_CLASS: casual

--- a/docs/casual.texi
+++ b/docs/casual.texi
@@ -20,7 +20,7 @@ Copyright © 2024-2025 Charles Y@. Choi
 @finalout
 @titlepage
 @title Casual User Guide
-@subtitle for version 2.16.1
+@subtitle for version 2.16.2-rc.1
 @author Charles Y@. Choi (@email{kickingvegas@@gmail.com})
 @page
 @vskip 0pt plus 1filll
@@ -33,7 +33,7 @@ Copyright © 2024-2025 Charles Y@. Choi
 @node Top
 @top Casual User Guide
 
-Version: 2.16.1
+Version: 2.16.2-rc.1
 
 Copyright © 2024-2026 @w{Charles Y. Choi}
 

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -51,7 +51,8 @@ ASCII-range string."
 
 (defun casual-dired-marked-p ()
   "Predicate if Dired item is marked."
-  (if (derived-mode-p 'dired-mode)
+  (if (and (derived-mode-p 'dired-mode)
+           (> (- (line-end-position) (line-beginning-position)) 0))
       (char-equal (char-after (line-beginning-position)) dired-marker-char)
     nil))
 

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.16.1
+;; Version: 2.16.2-rc.1
 ;; Package-Requires: ((emacs "30.1") (transient "0.9.0") (csv-mode "1.27"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 2.16.2-rc.1**
  

- **Fix predicate casual-dired-marked-p**
  * lisp/casual-dired-utils.el (casual-dired-marked-p): Change predicate to
  account for when the point is in a blank line to test if the Dired item is
  marked.
  