### PR TITLE
Do not display async command output window when resizing image

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -36,6 +36,7 @@ eww						\
 help						\
 html						\
 ibuffer						\
+image						\
 info						\
 isearch						\
 ispell						\

--- a/lisp/casual-image-utils.el
+++ b/lisp/casual-image-utils.el
@@ -131,7 +131,12 @@ References
     (push geometry cmd-list)
     (push target cmd-list)
 
-    (let ((cmd (string-join (reverse cmd-list) " ")))
+    (let* ((async-buf-name (string-replace "*" "\\*"
+                                           shell-command-buffer-name-async))
+           (display-buffer-alist
+            (append display-buffer-alist
+                    `((,async-buf-name display-buffer-no-window))))
+           (cmd (string-join (reverse cmd-list) " ")))
       (async-shell-command cmd)
       (message "%s" cmd))))
 


### PR DESCRIPTION
* lisp/casual-image-utils.el (casual-image--resize): Amend display-buffer-alist
to not display output buffer for async-shell-command.
* lisp/Makefile (MODULES): Fix bug where image tests were not run in regression.
