### PR TITLE
Update regression to include llama

### DIFF
--- a/lisp/Makefile--defines.make
+++ b/lisp/Makefile--defines.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,3 +35,11 @@ CASUAL_BASE_DIR=$(abspath $(shell pwd)/..)
 CASUAL_LISP_DIR=$(CASUAL_BASE_DIR)/lisp
 CASUAL_TEST_INCLUDES=$(CASUAL_BASE_DIR)/tests/casual-lib-test-utils.el
 EMACS_ELPA_DIR=$(HOME)/.config/emacs/elpa
+
+PACKAGE_PATHS=					\
+-L $(EMACS_ELPA_DIR)/compat-current		\
+-L $(EMACS_ELPA_DIR)/seq-current		\
+-L $(EMACS_ELPA_DIR)/llama-current		\
+-L $(EMACS_ELPA_DIR)/transient-current		\
+-L $(EMACS_ELPA_DIR)/cond-let-current		\
+-L $(CASUAL_LISP_DIR)

--- a/lisp/Makefile-agenda.make
+++ b/lisp/Makefile-agenda.make
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-agenda-utils.el		\
 casual-agenda-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-agenda-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-bibtex.make
+++ b/lisp/Makefile-bibtex.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-bibtex-utils.el	\
 casual-bibtex-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-bibtex-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-bookmarks.make
+++ b/lisp/Makefile-bookmarks.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-bookmarks-utils.el	\
 casual-bookmarks-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-bookmarks-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-calc.make
+++ b/lisp/Makefile-calc.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -47,19 +47,5 @@ casual-calc-financial.el			\
 casual-calc-symbolic.el
 
 ELISP_TEST_INCLUDES=casual-calc-test-utils.el
-
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transpose-frame-current	\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/magit-current		\
--L $(EMACS_ELPA_DIR)/magit-section-current	\
--L $(EMACS_ELPA_DIR)/dash-current		\
--L $(EMACS_ELPA_DIR)/with-editor-current	\
--L $(EMACS_ELPA_DIR)/symbol-overlay-current	\
--L $(CASUAL_LISP_DIR)
-
 
 include Makefile--rules.make

--- a/lisp/Makefile-calendar.make
+++ b/lisp/Makefile-calendar.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,18 +22,6 @@ casual-calendar-utils.el	\
 casual-calendar-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-calendar-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transpose-frame-current	\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/magit-current		\
--L $(EMACS_ELPA_DIR)/magit-section-current	\
--L $(EMACS_ELPA_DIR)/dash-current		\
--L $(EMACS_ELPA_DIR)/with-editor-current	\
--L $(EMACS_ELPA_DIR)/symbol-overlay-current	\
--L $(CASUAL_LISP_DIR)
 
 
 include Makefile--rules.make

--- a/lisp/Makefile-compile.make
+++ b/lisp/Makefile-compile.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-compile-utils.el	\
 casual-compile-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-compile-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-css.make
+++ b/lisp/Makefile-css.make
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-css-utils.el	\
 casual-css-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-css-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-csv.make
+++ b/lisp/Makefile-csv.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,12 +21,7 @@ ELISP_INCLUDES=casual-csv-utils.el		\
 casual-csv-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-csv-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/csv-mode-current		\
--L $(CASUAL_LISP_DIR)
+PACKAGE_PATHS:=$(PACKAGE_PATHS) \
+-L $(EMACS_ELPA_DIR)/csv-mode-current
 
 include Makefile--rules.make

--- a/lisp/Makefile-dired.make
+++ b/lisp/Makefile-dired.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,12 +19,6 @@ PACKAGE_NAME=casual-dired
 ELISP_INCLUDES=casual-dired-variables.el casual-dired-utils.el
 ELISP_PACKAGES=casual-dired-settings.el casual-dired-sort-by.el
 ELISP_TEST_INCLUDES=casual-dired-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 
 include Makefile--rules.make

--- a/lisp/Makefile-ediff.make
+++ b/lisp/Makefile-ediff.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,16 +21,5 @@ ELISP_INCLUDES=casual-ediff-utils.el	\
 casual-ediff-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-ediff-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/magit-current		\
--L $(EMACS_ELPA_DIR)/magit-section-current	\
--L $(EMACS_ELPA_DIR)/dash-current		\
--L $(EMACS_ELPA_DIR)/with-editor-current	\
--L $(EMACS_ELPA_DIR)/llama-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-editkit.make
+++ b/lisp/Makefile-editkit.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,17 +21,10 @@ casual-editkit-settings.el			\
 casual-editkit-utils.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-editkit-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transpose-frame-current	\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
+PACKAGE_PATHS:=$(PACKAGE_PATHS)			\
 -L $(EMACS_ELPA_DIR)/magit-current		\
 -L $(EMACS_ELPA_DIR)/magit-section-current	\
--L $(EMACS_ELPA_DIR)/dash-current		\
 -L $(EMACS_ELPA_DIR)/with-editor-current	\
--L $(EMACS_ELPA_DIR)/symbol-overlay-current	\
--L $(CASUAL_LISP_DIR)
+-L $(EMACS_ELPA_DIR)/symbol-overlay-current
 
 include Makefile--rules.make

--- a/lisp/Makefile-elisp.make
+++ b/lisp/Makefile-elisp.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-elisp-utils.el	\
 casual-elisp-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-elisp-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-eshell.make
+++ b/lisp/Makefile-eshell.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,16 +21,5 @@ ELISP_INCLUDES=casual-eshell-utils.el	\
 casual-eshell-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-eshell-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/magit-current		\
--L $(EMACS_ELPA_DIR)/magit-section-current	\
--L $(EMACS_ELPA_DIR)/dash-current		\
--L $(EMACS_ELPA_DIR)/with-editor-current	\
--L $(EMACS_ELPA_DIR)/llama-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-eww.make
+++ b/lisp/Makefile-eww.make
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-eww-utils.el	\
 casual-eww-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-eww-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-help.make
+++ b/lisp/Makefile-help.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-help-utils.el		\
 casual-help-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-help-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-html.make
+++ b/lisp/Makefile-html.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-html-utils.el	\
 casual-html-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-html-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-ibuffer.make
+++ b/lisp/Makefile-ibuffer.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,11 +20,5 @@ ELISP_INCLUDES=casual-ibuffer-utils.el		\
 casual-ibuffer-settings.el
 ELISP_PACKAGES=casual-ibuffer-filter.el
 ELISP_TEST_INCLUDES=casual-ibuffer-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-image.make
+++ b/lisp/Makefile-image.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,11 +20,5 @@ PACKAGE_NAME=casual-image
 ELISP_INCLUDES=casual-image-utils.el casual-image-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-image-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-info.make
+++ b/lisp/Makefile-info.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,12 +20,6 @@ PACKAGE_NAME=casual-info
 ELISP_INCLUDES=casual-info-variables.el casual-info-utils.el
 ELISP_PACKAGES=casual-info-settings.el
 ELISP_TEST_INCLUDES=casual-info-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 
 include Makefile--rules.make

--- a/lisp/Makefile-isearch.make
+++ b/lisp/Makefile-isearch.make
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-isearch-utils.el		\
 casual-isearch-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-isearch-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-ispell.make
+++ b/lisp/Makefile-ispell.make
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-ispell-utils.el	\
 casual-ispell-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-ispell-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-lib.make
+++ b/lisp/Makefile-lib.make
@@ -20,12 +20,6 @@ ELISP_INCLUDES=
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-lib-test-utils.el
 PACKAGE_NAME=casual-lib
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 
 .PHONY: tests compile regression

--- a/lisp/Makefile-make-mode.make
+++ b/lisp/Makefile-make-mode.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-make-utils.el	\
 casual-make-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-make-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-man.make
+++ b/lisp/Makefile-man.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-man-utils.el	\
 casual-man-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-man-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-org.make
+++ b/lisp/Makefile-org.make
@@ -21,12 +21,7 @@ ELISP_INCLUDES=casual-org-utils.el	\
 casual-org-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-org-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(EMACS_ELPA_DIR)/org-current		\
--L $(CASUAL_LISP_DIR)
+PACKAGE_PATHS:=$(PACKAGE_PATHS)				\
+-L $(EMACS_ELPA_DIR)/org-current
 
 include Makefile--rules.make

--- a/lisp/Makefile-re-builder.make
+++ b/lisp/Makefile-re-builder.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2024-2025 Charles Y. Choi
+# Copyright (C) 2024-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-re-builder-utils.el	\
 casual-re-builder-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-re-builder-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make

--- a/lisp/Makefile-timezone.make
+++ b/lisp/Makefile-timezone.make
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2025 Charles Y. Choi
+# Copyright (C) 2025-2026 Charles Y. Choi
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,5 @@ ELISP_INCLUDES=casual-timezone-utils.el	\
 casual-timezone-settings.el
 ELISP_PACKAGES=
 ELISP_TEST_INCLUDES=casual-timezone-test-utils.el
-PACKAGE_PATHS=					\
--L $(EMACS_ELPA_DIR)/compat-current		\
--L $(EMACS_ELPA_DIR)/seq-current		\
--L $(EMACS_ELPA_DIR)/transient-current		\
--L $(EMACS_ELPA_DIR)/cond-let-current		\
--L $(CASUAL_LISP_DIR)
 
 include Makefile--rules.make


### PR DESCRIPTION
Adds support for including current release of llama package due to Transient
dependency. Bulk cleanup of Makefiles for different modes.
