### PR TITLE
Fix for async image resize display-buffer-alist

### DIFF
--- a/lisp/casual-image-utils.el
+++ b/lisp/casual-image-utils.el
@@ -134,11 +134,16 @@ References
 
     (let* ((async-buf-name (string-replace "*" "\\*"
                                            shell-command-buffer-name-async))
-           (awin-config `((,async-buf-name display-buffer-no-window)))
-           (display-buffer-alist
-            (map-put! display-buffer-alist async-buf-name awin-config))
+           (awin-config (list #'display-buffer-no-window))
+           (old-value (map-elt display-buffer-alist async-buf-name))
            (cmd (string-join (reverse cmd-list) " ")))
+
+      (map-put! display-buffer-alist async-buf-name awin-config)
       (async-shell-command cmd)
+      (if old-value
+          (map-put! display-buffer-alist async-buf-name old-value)
+        (setq display-buffer-alist
+              (assoc-delete-all async-buf-name display-buffer-alist)))
       (message "%s" cmd))))
 
 


### PR DESCRIPTION
* lisp/casual-image-utils.el (casual-image--resize): Prior code presumed wrongly
that display-buffer-alist could be locally bound. It cannot. Fix is to
checkpoint and restore display-buffer-alist accordingly.
