### PR TITLE
Fix Elisp page separators

### DIFF
--- a/lisp/casual-csv-settings.el
+++ b/lisp/casual-csv-settings.el
@@ -66,8 +66,7 @@
    (casual-lib-quit-all)])
 
 
-;; -------------------------------------------------------------------
-;; Functions
+;;; Functions
 
 (defun casual-csv--customize-group ()
   "Customize csv group."

--- a/lisp/casual-csv-utils.el
+++ b/lisp/casual-csv-utils.el
@@ -81,8 +81,7 @@ plain ASCII-range string."
   (call-interactively #'csv-align-fields))
 
 
-;; -------------------------------------------------------------------
-;; Transients
+;;; Transients
 (transient-define-prefix casual-csv-align-tmenu ()
   ["Align"
    :description (lambda () (format

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -74,8 +74,7 @@ ASCII-range string."
     nil))
 
 
-;; -------------------------------------------------------------------
-;; Transients
+;;; Transients
 
 (transient-define-prefix casual-dired-utils-tmenu ()
   ["Utils - Marked Files or File under Point"

--- a/lisp/casual-ediff-utils.el
+++ b/lisp/casual-ediff-utils.el
@@ -59,7 +59,6 @@ plain ASCII-range string."
   (casual-lib-unicode-db-get key casual-ediff-unicode-db))
 
 
-;; -------------------------------------------------------------------
 ;;; Format
 
 (defun casual-ediff--buffer-description (ebuf slot &optional extend)
@@ -82,7 +81,6 @@ plain ASCII-range string."
       (format "%s: %s" slot filename))))
 
 
-;; -------------------------------------------------------------------
 ;;; Ediff Functions
 (defun casual-ediff-info ()
   "Open Info for Ediff."

--- a/lisp/casual-eww-utils.el
+++ b/lisp/casual-eww-utils.el
@@ -66,7 +66,6 @@ plain ASCII-range string."
   (interactive) (info "(eww) Top"))
 
 
-;; -------------------------------------------------------------------
 ;;; Commands
 (defun casual-eww-forward-paragraph-link ()
   "Move point to first link in next paragraph."
@@ -85,7 +84,6 @@ plain ASCII-range string."
     (shr-next-link)))
 
 
-;; -------------------------------------------------------------------
 ;;; Transients
 
 (transient-define-prefix casual-eww-display-tmenu ()

--- a/lisp/casual-org-settings.el
+++ b/lisp/casual-org-settings.el
@@ -25,8 +25,7 @@
 (require 'casual-lib)
 
 
-;; -------------------------------------------------------------------
-;; Customize Functions
+;;; Customize Functions
 
 ;; Groups
 (defun casual-org--customize-group ()
@@ -150,7 +149,6 @@ Always choose love."
   (describe-function #'casual-org-about-org))
 
 
-;; -------------------------------------------------------------------
 ;; Transients
 (transient-define-prefix casual-org-settings-tmenu ()
   "Casual Org settings menu."

--- a/lisp/casual-org-utils.el
+++ b/lisp/casual-org-utils.el
@@ -144,7 +144,6 @@ level of the Org manual is opened."
   (derived-mode-p 'org-mode))
 
 
-;; -------------------------------------------------------------------
 ;; Org List Functions
 
 (defun casual-org-checkbox-in-progress ()
@@ -167,7 +166,6 @@ which is done with `org-ctrl-c-ctrl-c'."
   (org-insert-item t))
 
 
-;; -------------------------------------------------------------------
 ;; Org Block & Table Functions
 
 (defun casual-org-assign-name (name)
@@ -241,7 +239,6 @@ This command should only be invoked in an empty table cell."
     (casual-org-table--insert-column-alignment fn)))
 
 
-;; -------------------------------------------------------------------
 ;; Org Section Descriptions
 
 (defun casual-org--block-description ()
@@ -356,7 +353,6 @@ This command should only be invoked in an empty table cell."
       "Org Item")))
 
 
-;; -------------------------------------------------------------------
 ;; Org Table Functions
 
 (defun casual-org-table--cell-at-point ()
@@ -550,7 +546,6 @@ See `casual-org-table--range' for more on RANGE object."
     (kill-new value)))
 
 
-;; -------------------------------------------------------------------
 ;; fedit functions
 
 (defun casual-org-table-fedit-first-row-reference ()
@@ -589,7 +584,6 @@ See `casual-org-table--range' for more on RANGE object."
   (insert "@I..@II"))
 
 
-;; -------------------------------------------------------------------
 ;; Image Preview
 
 (defun casual-org-toggle-images ()
@@ -603,7 +597,6 @@ Org 9.8."
     (org-link-preview 11)))
 
 
-;; -------------------------------------------------------------------
 ;; Transients
 
 ;; Transient Groups

--- a/tests/test-casual-editkit-utils.el
+++ b/tests/test-casual-editkit-utils.el
@@ -867,6 +867,5 @@
   ;;     (casualt-editkit-breakdown tmpfile)))
   )
 
-;; -------
 (provide 'test-casual-editkit-utils)
 ;;; test-casual-editkit-utils.el ends here


### PR DESCRIPTION
Modify comment after page-break (^L) to conform to Elisp page navigation commands.
