### PR TITLE
Add autoloads for Transient prefixes

### DIFF
--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -76,6 +76,7 @@ ASCII-range string."
 
 ;;; Transients
 
+;;;###autoload (autoload 'casual-dired-utils-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-utils-tmenu ()
   ["Utils - Marked Files or File under Point"
    ["Files"
@@ -113,6 +114,7 @@ ASCII-range string."
 
   casual-lib-navigation-group-with-return)
 
+;;;###autoload (autoload 'casual-dired-elisp-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-elisp-tmenu ()
   ["Emacs Lisp"
    ["Byte-Compile"
@@ -127,6 +129,7 @@ ASCII-range string."
 
   casual-lib-navigation-group-with-return)
 
+;;;###autoload (autoload 'casual-dired-link-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-link-tmenu ()
   ["Link"
    ["Symbolic"

--- a/lisp/casual-ediff-utils.el
+++ b/lisp/casual-ediff-utils.el
@@ -100,6 +100,7 @@ function `ediff-janitor'.")
   (ignore e)
   (casual-ediff-revision))
 
+;;;###autoload (autoload 'casual-ediff-revision "casual-ediff-utils" nil t)
 (defun casual-ediff-revision ()
   "Run Ediff comparing current file with last committed version.
 

--- a/lisp/casual-image.el
+++ b/lisp/casual-image.el
@@ -27,6 +27,7 @@
 (require 'casual-image-utils)
 (require 'casual-image-settings)
 
+;;;###autoload (autoload 'casual-image-tmenu "casual-image" nil t)
 (transient-define-prefix casual-image-tmenu ()
   "Casual Image Main Menu."
   :refresh-suffixes t


### PR DESCRIPTION
* lisp/casual-dired-utils.el
  - casual-dired-utils-tmenu
  - casual-dired-elisp-tmenu
  - casual-dired-link-tmenu

* lisp/casual-ediff-utils.el
  - casual-ediff-revision

* lisp/casual-image.el
  - casual-image-tmenu
