### PR TITLE
Merge development to main 20260718_110035

### DIFF
--- a/docs/casual.org
+++ b/docs/casual.org
@@ -5,7 +5,7 @@
 #+EMAIL: kickingvegas@gmail.com
 #+OPTIONS: ':t toc:t author:t email:t H:4 f:t
 #+LANGUAGE: en
-#+MACRO: version 2.17.0
+#+MACRO: version 2.17.1-rc.1
 #+MACRO: kbd (eval (org-texinfo-kbd-macro $1))
 #+TEXINFO_FILENAME: casual.info
 #+TEXINFO_CLASS: casual

--- a/docs/casual.texi
+++ b/docs/casual.texi
@@ -20,7 +20,7 @@ Copyright © 2024-2025 Charles Y@. Choi
 @finalout
 @titlepage
 @title Casual User Guide
-@subtitle for version 2.17.0
+@subtitle for version 2.17.1-rc.1
 @author Charles Y@. Choi (@email{kickingvegas@@gmail.com})
 @page
 @vskip 0pt plus 1filll
@@ -33,7 +33,7 @@ Copyright © 2024-2025 Charles Y@. Choi
 @node Top
 @top Casual User Guide
 
-Version: 2.17.0
+Version: 2.17.1-rc.1
 
 Copyright © 2024-2026 @w{Charles Y. Choi}
 

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -76,6 +76,7 @@ ASCII-range string."
 
 ;;; Transients
 
+;;;###autoload (autoload 'casual-dired-utils-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-utils-tmenu ()
   ["Utils - Marked Files or File under Point"
    ["Files"
@@ -113,6 +114,7 @@ ASCII-range string."
 
   casual-lib-navigation-group-with-return)
 
+;;;###autoload (autoload 'casual-dired-elisp-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-elisp-tmenu ()
   ["Emacs Lisp"
    ["Byte-Compile"
@@ -127,6 +129,7 @@ ASCII-range string."
 
   casual-lib-navigation-group-with-return)
 
+;;;###autoload (autoload 'casual-dired-link-tmenu "casual-dired-utils" nil t)
 (transient-define-prefix casual-dired-link-tmenu ()
   ["Link"
    ["Symbolic"

--- a/lisp/casual-ediff-utils.el
+++ b/lisp/casual-ediff-utils.el
@@ -100,6 +100,7 @@ function `ediff-janitor'.")
   (ignore e)
   (casual-ediff-revision))
 
+;;;###autoload (autoload 'casual-ediff-revision "casual-ediff-utils" nil t)
 (defun casual-ediff-revision ()
   "Run Ediff comparing current file with last committed version.
 

--- a/lisp/casual-image.el
+++ b/lisp/casual-image.el
@@ -27,6 +27,7 @@
 (require 'casual-image-utils)
 (require 'casual-image-settings)
 
+;;;###autoload (autoload 'casual-image-tmenu "casual-image" nil t)
 (transient-define-prefix casual-image-tmenu ()
   "Casual Image Main Menu."
   :refresh-suffixes t

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools, wp
-;; Version: 2.17.0
+;; Version: 2.17.1-rc.1
 ;; Package-Requires: ((emacs "30.1") (transient "0.9.0") (csv-mode "1.27"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 2.17.1-rc.1**
  

- **Add autoloads for Transient prefixes**
  * lisp/casual-dired-utils.el
    - casual-dired-utils-tmenu
    - casual-dired-elisp-tmenu
    - casual-dired-link-tmenu
  
  * lisp/casual-ediff-utils.el
    - casual-ediff-revision
  
  * lisp/casual-image.el
    - casual-image-tmenu
  