### PR TITLE
Amend casual-init instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -42,6 +42,7 @@ Certain menus require more installed software:
 Casual versions 3.0 or greater offer a simplified installation with command ~casual-init~. Run this via ~extended-execute-command~ (~M-x~) or add this to your Emacs initialization file.
 
 #+begin_src elisp :lexical no
+  (require 'casual)
   (casual-init)
 #+end_src
 

--- a/docs/casual.org
+++ b/docs/casual.org
@@ -161,6 +161,7 @@ Given installation via ~package-install~ ([[info:emacs#Package Installation]]), 
 Casual versions 3.0 or greater offer a simplified installation with command ~casual-init~. Run this via ~extended-execute-command~ ({{{kbd(M-x)}}}) or add this to your Emacs initialization file.
 
 #+begin_src elisp :lexical no
+  (require 'casual)
   (casual-init)
 #+end_src
 

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -122,6 +122,7 @@
 ;; Simplified installation is done via the command `casual-init'. Run this via
 ;; extended-execute-command (M-x) or add this to your Emacs initialization file.
 
+;;   (require 'casual)
 ;;   (casual-init)
 
 ;; By default `casual-init' will setup keybindings for all modules supported by
@@ -180,15 +181,6 @@ casual-suite, casual-avy, or casual-symbol-overlay is installed."
                 (package-refresh-contents)))
             pkglist))))
 
-(defun casual-get-package-version (pkg)	;this is an unused, non-interactive function?
-  "Get package version of symbol PKG."
-  (let* ((pkg-name (symbol-name pkg))
-         (pkg-buf (find-library pkg-name))
-         (buflist (list pkg-name)))
-    (with-current-buffer pkg-buf
-      (push (package-get-version) buflist))
-    (kill-buffer pkg-buf)
-    (string-join (reverse buflist) "-")))
 
 ;;;###autoload (autoload 'casual-init "casual" nil t)
 (defun casual-init ()


### PR DESCRIPTION
* README.org (Install): Add `(require 'casual)`.
* docs/casual.org (Install): Add `(require 'casual)`.
* lisp/casual.el (casual-init): Amend commentary, remove `casual-get-package-version`.
